### PR TITLE
Correct the ordering of the headers so that the pacparser.h header is included when configured.

### DIFF
--- a/main.c
+++ b/main.c
@@ -43,9 +43,6 @@
 #include <termios.h>
 #include <fnmatch.h>
 #include <assert.h>
-#ifdef ENABLE_PACPARSER
-#include <pacparser.h>
-#endif
 #ifdef __CYGWIN__
 #include <windows.h>
 #endif
@@ -73,6 +70,9 @@
 
 #ifdef ENABLE_KERBEROS
 #include "kerberos.h"
+#endif
+#ifdef ENABLE_PACPARSER
+#include <pacparser.h>
 #endif
 
 #define STACK_SIZE	sizeof(void *)*8*1024


### PR DESCRIPTION
Unfortunately I made a very silly mistake when making PAC support optional.

The ifdef should be below the inclusion of the config.h header.

This PR solves my mistake.