### PR TITLE
Add option for static linking via --enable-static

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,12 @@ ifeq ($(ENABLE_PACPARSER),1)
 	LDFLAGS+=-lpacparser
 endif
 
-#CFLAGS+=-g
+
+ENABLE_STATIC=$(shell grep -c ENABLE_STATIC config/config.h)
+ifeq ($(ENABLE_STATIC),1)
+        LDFLAGS+=-static
+endif
+
 
 all: $(NAME)
 

--- a/configure
+++ b/configure
@@ -109,6 +109,10 @@ do
 			printf "#define ENABLE_PACPARSER" >> $CONFIG
 			echo "" >> $CONFIG
 			;;
+        --enable-static)
+            printf "#define ENABLE_STATIC" >> $CONFIG
+            echo "" >> $CONFIG
+            ;;
 		*)
 			echo "Unknown flag $1"
 			rm -f $CONFIG


### PR DESCRIPTION
Hello, I'm not sure if you (or anyone) is an authoritative maintainer of CNTLM at this point- but your fork was the most up to date one I could find. If you're interested, I added an `--enable-static` flag to `configure` file as well as the `Makefile`

 I'm using this branch with a musl-libc toolchain to statically link cntlm with libpacparser support. It's a bigger file of course but doesn't require any dependencies (or require any specific versions of any dependencies) which is useful in my environment
 
 Thanks
 
 (You'll see I also removed an orphaned, commented out debug symbols flag line, the debug symbols are set higher up in the file in a proper conditional block so it seems it's just old clutter)
