### PR TITLE
improve macos support

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -13,7 +13,30 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: configure
-      run: ./configure
-    - name: make
-      run: make
+    - name: Install packages required for optional configurations of cntlm
+      run: brew install pacparser krb5
+    - name: Normal build
+      run: |
+        ./configure
+        make
+        make distclean
+    - name: Unicode build
+      run: |
+        ./configure
+        CFLAGS=-DUNICODE make
+        make distclean
+    - name: Build with pacparser enabled
+      run: |
+        ./configure --enable-pacparser
+        make
+        make distclean
+    - name: Build with kerberos enabled
+      run: |
+        ./configure --enable-kerberos
+        make
+        make distclean
+    - name: Verify debug build
+      run: |
+        ./configure
+        make DEBUG=1
+        make distclean

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install packages required for optional configurations of cntlm
-      run: brew install pacparser krb5
+      run: brew install pacparser krb5 fakeroot
     - name: Normal build
       run: |
         ./configure

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ cntlm*.tar.gz
 /config/gethostname
 /config/socklen_t
 /config/strdup
+/config/arc4random_buf
+/config/strlcat
+/config/strlcpy
 /config/*.exe
 /win/*.exe
 /win/*.dll

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ GCC_GTEQ_450 := $(shell expr `${CC} -dumpversion | sed -e 's/\.\([0-9][0-9]\)/\1
 GCC_GTEQ_600 := $(shell expr `${CC} -dumpversion | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/'` \>= 60000)
 GCC_GTEQ_700 := $(shell expr `${CC} -dumpversion | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/'` \>= 70000)
 
-CFLAGS	+= -std=c99 -D__BSD_VISIBLE -D_ALL_SOURCE -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200112 -D_ISOC99_SOURCE -D_REENTRANT -D_BSD_SOURCE -DVERSION=\"'$(VER)'\"
+CFLAGS	+= -std=c99 -D__BSD_VISIBLE -D_ALL_SOURCE -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200112 -D_ISOC99_SOURCE -D_REENTRANT -D_BSD_SOURCE -D_DARWIN_C_SOURCE -DVERSION=\"'$(VER)'\"
 CFLAGS	+= -Wall -Wextra -pedantic -Wshadow -Wcast-qual -Wbad-function-cast -Wstrict-prototypes
 #CFLAGS  += -ftrapv
 #CFLAGS  += -fsanitize=undefined -fsanitize-undefined-trap-on-error
@@ -206,7 +206,7 @@ uninstall:
 	rm -f $(BINDIR)/$(NAME) $(MANDIR)/man1/$(NAME).1 2>/dev/null || true
 
 clean:
-	@rm -f config/endian config/gethostname config/strdup config/socklen_t config/arc4random_buf config/*.exe
+	@rm -f config/endian config/gethostname config/strdup config/socklen_t config/arc4random_buf config/strlcat config/strlcpy config/*.exe
 	@rm -f *.o cntlm cntlm.exe configure-stamp build-stamp config/config.h
 	rm -f $(patsubst %, win/%, $(CYGWIN_REQS) cntlm.exe cntlm.ini LICENSE.txt resources.o setup.iss cntlm_manual.pdf)
 	@if [ -h Makefile ]; then rm -f Makefile; mv Makefile.gcc Makefile; fi

--- a/Makefile.clang
+++ b/Makefile.clang
@@ -20,7 +20,7 @@ OSLDFLAGS	:= $(shell [ $(OS) = "SunOS" ] && echo "-lrt -lsocket -lnsl")
 LDFLAGS		:= -lpthread $(OSLDFLAGS)
 CYGWIN_REQS	:= cygwin1.dll cyggcc_s-seh-1.dll cygstdc++-6.dll cygrunsrv.exe 
 
-CFLAGS	+= -std=c99 -D__BSD_VISIBLE -D_ALL_SOURCE -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200112 -D_ISOC99_SOURCE -D_REENTRANT -D_BSD_SOURCE -DVERSION=\"'$(VER)'\"
+CFLAGS	+= -std=c99 -D__BSD_VISIBLE -D_ALL_SOURCE -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200112 -D_ISOC99_SOURCE -D_REENTRANT -D_BSD_SOURCE -D_DARWIN_C_SOURCE -DVERSION=\"'$(VER)'\"
 CFLAGS	+= -Wall -Wextra -pedantic -Wshadow -Wcast-qual -Wbad-function-cast -Wstrict-prototypes
 #CFLAGS	+= -v
 ifeq ($(DEBUG),1)
@@ -181,7 +181,7 @@ uninstall:
 	rm -f $(BINDIR)/$(NAME) $(MANDIR)/man1/$(NAME).1 2>/dev/null || true
 
 clean:
-	@rm -f config/endian config/gethostname config/strdup config/socklen_t config/arc4random_buf config/*.exe
+	@rm -f config/endian config/gethostname config/strdup config/socklen_t config/arc4random_buf config/strlcat config/strlcpy config/*.exe
 	@rm -f *.o cntlm cntlm.exe configure-stamp build-stamp config/config.h
 	rm -f $(patsubst %, win/%, $(CYGWIN_REQS) cntlm.exe cntlm.ini LICENSE.txt resources.o setup.iss cntlm_manual.pdf)
 	@if [ -h Makefile ]; then rm -f Makefile; mv Makefile.gcc Makefile; fi

--- a/Makefile.ikos-scan-cc
+++ b/Makefile.ikos-scan-cc
@@ -20,7 +20,7 @@ OSLDFLAGS	:= $(shell [ $(OS) = "SunOS" ] && echo "-lrt -lsocket -lnsl")
 LDFLAGS		:= -lpthread $(OSLDFLAGS)
 CYGWIN_REQS	:= cygwin1.dll cyggcc_s-seh-1.dll cygstdc++-6.dll cygrunsrv.exe 
 
-CFLAGS	+= -std=c99 -D__BSD_VISIBLE -D_ALL_SOURCE -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200112 -D_ISOC99_SOURCE -D_REENTRANT -D_BSD_SOURCE -DVERSION=\"'$(VER)'\"
+CFLAGS	+= -std=c99 -D__BSD_VISIBLE -D_ALL_SOURCE -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200112 -D_ISOC99_SOURCE -D_REENTRANT -D_BSD_SOURCE -D_DARWIN_C_SOURCE -DVERSION=\"'$(VER)'\"
 CFLAGS	+= -Wall -Wextra -pedantic -Wshadow -Wcast-qual -Wbad-function-cast -Wstrict-prototypes
 #CFLAGS	+= -fstack-protector-strong
 #CFLAGS	+= -v
@@ -162,7 +162,7 @@ uninstall:
 	rm -f $(BINDIR)/$(NAME) $(MANDIR)/man1/$(NAME).1 2>/dev/null || true
 
 clean:
-	@rm -f config/endian config/gethostname config/strdup config/socklen_t config/arc4random_buf config/*.exe
+	@rm -f config/endian config/gethostname config/strdup config/socklen_t config/arc4random_buf config/strlcat config/strlcpy config/*.exe
 	@rm -f *.o cntlm cntlm.exe configure-stamp build-stamp config/config.h
 	rm -f $(patsubst %, win/%, $(CYGWIN_REQS) cntlm.exe cntlm.ini LICENSE.txt resources.o setup.iss cntlm_manual.pdf)
 	@if [ -h Makefile ]; then rm -f Makefile; mv Makefile.gcc Makefile; fi

--- a/config/strlcat.c
+++ b/config/strlcat.c
@@ -3,7 +3,7 @@
 int main(int argc, char **argv) {
 	int retval;
 	int size = 16;
-	char buffer[size];
+	char buffer[size] = {0};
 
 	retval = strlcat(buffer, "hello", size);
 	retval = strlcat(buffer, " world!", size);

--- a/config/strlcat.c
+++ b/config/strlcat.c
@@ -6,7 +6,6 @@ int main(int argc, char **argv) {
 	char buffer[size] = {0};
 
 	retval = strlcat(buffer, "hello", size);
-	retval = strlcat(buffer, " world!", size);
 
 	return !!retval;
 }

--- a/config/strlcat.c
+++ b/config/strlcat.c
@@ -1,11 +1,12 @@
 #include <string.h>
 
+#define BUFFER_SIZE 16
+
 int main(int argc, char **argv) {
 	int retval;
-	int size = 16;
-	char buffer[size] = {0};
+	char buffer[BUFFER_SIZE] = {0};
 
-	retval = strlcat(buffer, "hello", size);
+	retval = strlcat(buffer, "hello", BUFFER_SIZE);
 
 	return !!retval;
 }

--- a/config/strlcat.c
+++ b/config/strlcat.c
@@ -1,0 +1,12 @@
+#include <string.h>
+
+int main(int argc, char **argv) {
+	int retval;
+	int size = 16;
+	char buffer[size];
+
+	retval = strlcat(buffer, "hello", size);
+	retval = strlcat(buffer, " world!", size);
+
+	return !!retval;
+}

--- a/config/strlcpy.c
+++ b/config/strlcpy.c
@@ -1,0 +1,11 @@
+#include <string.h>
+
+int main(int argc, char **argv) {
+	int retval;
+	int size = 8;
+	char buffer[size];
+
+	retval = strlcpy(buffer, "hello", size);
+
+	return !!retval;
+}

--- a/config/strlcpy.c
+++ b/config/strlcpy.c
@@ -1,11 +1,12 @@
 #include <string.h>
 
+#define BUFFER_SIZE 16
+
 int main(int argc, char **argv) {
 	int retval;
-	int size = 8;
-	char buffer[size] = {0};
+	char buffer[BUFFER_SIZE] = {0};
 
-	retval = strlcpy(buffer, "hello", size);
+	retval = strlcpy(buffer, "hello", BUFFER_SIZE);
 
 	return !!retval;
 }

--- a/config/strlcpy.c
+++ b/config/strlcpy.c
@@ -3,7 +3,7 @@
 int main(int argc, char **argv) {
 	int retval;
 	int size = 8;
-	char buffer[size];
+	char buffer[size] = {0};
 
 	retval = strlcpy(buffer, "hello", size);
 

--- a/configure
+++ b/configure
@@ -70,7 +70,7 @@ fi
 
 STAMP=configure-stamp
 CONFIG=config/config.h
-TESTS="endian strdup socklen_t gethostname arc4random_buf"
+TESTS="endian strdup socklen_t gethostname arc4random_buf strlcat strlcpy"
 
 #[ -f $STAMP ] && exit 0
 touch $STAMP
@@ -82,7 +82,7 @@ echo "" >> $CONFIG
 for i in $TESTS; do
 	printf "Checking $i... "
 	printf "#define config_$i " >> $CONFIG
-	OUT=`$CC -D_POSIX_C_SOURCE=199506L -D_ISOC99_SOURCE -D_REENTRANT -o config/$i config/$i.c 2>&1`
+	OUT=`$CC -std=c99 -D__BSD_VISIBLE -D_ALL_SOURCE -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200112 -D_ISOC99_SOURCE -D_REENTRANT -D_BSD_SOURCE -D_DARWIN_C_SOURCE -o config/$i config/$i.c 2>&1`
 	rc=$?
 
 	if [ $rc -ne 0 ]; then # -o -n "$OUT" ]; then

--- a/utils.c
+++ b/utils.c
@@ -724,6 +724,7 @@ char *strdup(const char *src) {
 }
 #endif
 
+#if config_strlcpy == 0
 /*
  * More intuitive version of strncpy with string termination
  * from OpenBSD
@@ -753,7 +754,9 @@ size_t strlcpy(char *dst, const char *src, size_t siz) {
 
 	return (s - src - 1);	/* count does not include NUL */
 }
+#endif
 
+#if config_strlcat == 0
 /*
  * More intuitive version of strncat with string termination
  * from OpenBSD
@@ -789,6 +792,7 @@ size_t strlcat(char *dst, const char *src, size_t siz) {
 
 	return (dlen + (s - src));	/* count does not include NUL */
 }
+#endif
 
 /*
  * Allocates memory and makes sure it is zero initialized.

--- a/utils.h
+++ b/utils.h
@@ -136,8 +136,12 @@ extern hlist_t hlist_free(hlist_t list);
 extern void hlist_dump(hlist_const_t list);
 
 extern char *substr(const char *src, int pos, int len) __attribute__((warn_unused_result));
+#if config_strlcpy == 0
 extern size_t strlcpy(char *dst, const char *src, size_t siz);
+#endif
+#if config_strlcat == 0
 extern size_t strlcat(char *dst, const char *src, size_t siz);
+#endif
 extern char *trimr(char * const buf);
 extern char *lowercase(char * const str);
 extern char *uppercase(char * const str);


### PR DESCRIPTION
PR #40 solves the issue of compiling on macOS, but only for the basic version of _cntlm_. When you add support for _pacaparser_ (`--enable-pacparser`) the compiler cannot find the `strsep()` standard function.

This can be fixed by setting the macro `_DARWIN_C_SOURCE` which tells the compiler to support Darwin extensions (by default the namespace is set to the same as `_POSIX_C_SOURCE`).

The problem is that this macro puts in scope also `strlcat()`and `strlcpy()`, the BSD functions that are defined in `utils.h` and `utils.c`. This raises another compilation error due to a conflict of these double definitions.

My solution is to make the custom implementation of `strlcat()`and `strlcpy()` optional, based on the availability on the target platform, in a similar way it is done for `strdup()` and other functions.

Hence, this PR does the following:
- add `_DARWIN_C_SOURCE` on the `CFLAGS` parameters for the compiler. This macro is not relevant on platform other than _Darwin_.
- set the same set of macros in the _configure_ tests, so that the correct configuration is detected for the platform.
- add two new tests, _strlcat_ and _strlcpy_ for the availability of these functions.
- wrap the custom definitions in _utils.c/utils.h_ in macros that are enabled or disabled by these tests.

I tested this configuration also on Windows (Cygwin) and Linux (Ubuntu), and it works on both (the `_DARWIN_C_SOURCE` macro is ignored). On Cygwin `strlcat()`and `strlcpy()` are available while on Ubuntu they are not (I guess the package _libbsd-dev_ must be installed, but I didn't test it).