### PR TITLE
Initialise GSS only when GSS authentication is used

### DIFF
--- a/main.c
+++ b/main.c
@@ -1748,9 +1748,11 @@ int main(int argc, char **argv) {
 	}
 
 #ifdef ENABLE_KERBEROS
-	g_creds->haskrb |= check_credential();
-	if(g_creds->haskrb & KRB_CREDENTIAL_AVAILABLE)
-		syslog(LOG_INFO, "Using cached credential for GSS auth.\n");
+	if (g_creds->haskrb & KRB_FORCE_USE_KRB) {
+		g_creds->haskrb |= check_credential();
+		if(g_creds->haskrb & KRB_CREDENTIAL_AVAILABLE)
+			syslog(LOG_INFO, "Using cached credential for GSS auth.\n");
+	}
 #endif
 
 	/*


### PR DESCRIPTION
This PR fixes an issue that affects cntlm when built with `--enable-kerberos`.

In this scenario the `-a ntlm | nt | lm | gss` option specified by user is defaulted to `gss` every time a kerberos ticket is available.
So when user specifies NTLM authentication:
```
$ cntlm -a ntlm -c cntlm.conf
```
GSS is instead forced during initialisation ! This is not what user wants.

This simple patch restores expected behaviour.