### PR TITLE
Improve syslog debug logging

### DIFF
--- a/direct.c
+++ b/direct.c
@@ -195,7 +195,7 @@ rr_data_t direct_request(void *cdata, rr_data_const_t request) {
 	int conn_alive = 0;
 
 	int cd = ((struct thread_arg_s *)cdata)->fd;
-	char saddr[INET6_ADDRSTRLEN];
+	char saddr[INET6_ADDRSTRLEN] = {0};
 	INET_NTOP(&((struct thread_arg_s *)cdata)->addr, saddr, INET6_ADDRSTRLEN);
 
 	if (debug)
@@ -283,9 +283,7 @@ rr_data_t direct_request(void *cdata, rr_data_const_t request) {
 				hlist_dump(data[loop]->headers);
 
 			if (loop == 0 && data[0]->req) {
-				if (request_logging_level == 1) {
-					syslog(LOG_DEBUG, "%s %s %s", saddr, data[0]->method, data[0]->url);
-				}
+				syslog(LOG_DEBUG, "%s %s %s", saddr, data[0]->method, data[0]->url);
 
 				/*
 				 * Convert full proxy request URL into a relative URL
@@ -463,7 +461,7 @@ void direct_tunnel(void *thread_data) {
 
 	int cd = ((struct thread_arg_s *)thread_data)->fd;
 	char *thost = ((struct thread_arg_s *)thread_data)->target;
-	char saddr[INET6_ADDRSTRLEN];
+	char saddr[INET6_ADDRSTRLEN] = {0};
 	INET_NTOP(&((struct thread_arg_s *)thread_data)->addr, saddr, INET6_ADDRSTRLEN);
 
 	hostname = strdup(thost);

--- a/direct.c
+++ b/direct.c
@@ -195,6 +195,8 @@ rr_data_t direct_request(void *cdata, rr_data_const_t request) {
 	int conn_alive = 0;
 
 	int cd = ((struct thread_arg_s *)cdata)->fd;
+	char saddr[INET6_ADDRSTRLEN];
+	INET_NTOP(&((struct thread_arg_s *)cdata)->addr, saddr, INET6_ADDRSTRLEN);
 
 	if (debug)
 		printf("Direct thread processing...\n");
@@ -281,6 +283,9 @@ rr_data_t direct_request(void *cdata, rr_data_const_t request) {
 				hlist_dump(data[loop]->headers);
 
 			if (loop == 0 && data[0]->req) {
+				if (request_logging_level == 1) {
+					syslog(LOG_DEBUG, "%s %s %s", saddr, data[0]->method, data[0]->url);
+				}
 
 				/*
 				 * Convert full proxy request URL into a relative URL
@@ -458,6 +463,8 @@ void direct_tunnel(void *thread_data) {
 
 	int cd = ((struct thread_arg_s *)thread_data)->fd;
 	char *thost = ((struct thread_arg_s *)thread_data)->target;
+	char saddr[INET6_ADDRSTRLEN];
+	INET_NTOP(&((struct thread_arg_s *)thread_data)->addr, saddr, INET6_ADDRSTRLEN);
 
 	hostname = strdup(thost);
 	if ((pos = strchr(hostname, ':')) != NULL) {
@@ -468,6 +475,8 @@ void direct_tunnel(void *thread_data) {
 	sd = host_connect(hostname, port);
 	if (sd <= 0)
 		goto bailout;
+
+	syslog(LOG_DEBUG, "%s FORWARD %s", saddr, thost);
 
 	if (debug)
 		printf("Portforwarding to %s for client %d...\n", thost, cd);

--- a/forward.c
+++ b/forward.c
@@ -469,6 +469,8 @@ rr_data_t forward_request(void *thread_data, rr_data_t request) {
 	int sd;
 	assert(thread_data != NULL);
 	int cd = ((struct thread_arg_s *)thread_data)->fd;
+	char saddr[INET6_ADDRSTRLEN];
+	INET_NTOP(&((struct thread_arg_s *)thread_data)->addr, saddr, INET6_ADDRSTRLEN);
 
 beginning:
 #ifdef ENABLE_PACPARSER
@@ -620,6 +622,11 @@ beginning:
 			if (debug)
 				hlist_dump(data[loop]->headers);
 
+			if (loop == 0 && data[0]->req) {
+				if (request_logging_level == 1) {
+					syslog(LOG_DEBUG, "%s %s %s", saddr, data[0]->method, data[0]->url);
+				}
+			}
 
 shortcut:
 			/*
@@ -973,12 +980,16 @@ void forward_tunnel(void *thread_data) {
 	assert(thread_data != NULL);
 	int cd = ((struct thread_arg_s *)thread_data)->fd;
 	char *thost = ((struct thread_arg_s *)thread_data)->target;
+	char saddr[INET6_ADDRSTRLEN];
+	INET_NTOP(&((struct thread_arg_s *)thread_data)->addr, saddr, INET6_ADDRSTRLEN);
 
 	tcreds = new_auth();
 	sd = proxy_connect(tcreds);
 
 	if (sd < 0)
 		goto bailout;
+
+	syslog(LOG_DEBUG, "%s TUNNEL %s", saddr, thost);
 
 	if (debug)
 		printf("Tunneling to %s for client %d...\n", thost, cd);

--- a/forward.c
+++ b/forward.c
@@ -230,7 +230,7 @@ int proxy_authenticate(int *sd, rr_data_t request, rr_data_t response, struct au
 	buf = zmalloc(BUFSIZE);
 
 #ifdef ENABLE_KERBEROS
-	if(g_creds->haskrb && acquire_kerberos_token(curr_proxy, credentials, buf)) {
+	if(g_creds->haskrb && acquire_kerberos_token(curr_proxy, credentials, buf, BUFSIZE)) {
 		//pre auth, we try to authenticate directly with kerberos, without to ask if auth is needed
 		//we assume that if kdc releases a ticket for the proxy, then the proxy is configured for kerberos auth
 		//drawback is that later in the code cntlm logs that no auth is required because we have already authenticated
@@ -335,7 +335,7 @@ int proxy_authenticate(int *sd, rr_data_t request, rr_data_t response, struct au
 
 		if (tmp) {
 #ifdef ENABLE_KERBEROS
-			if(g_creds->haskrb && strncasecmp(tmp, "NEGOTIATE", 9) == 0 && acquire_kerberos_token(curr_proxy, credentials, buf)) {
+			if(g_creds->haskrb && strncasecmp(tmp, "NEGOTIATE", 9) == 0 && acquire_kerberos_token(curr_proxy, credentials, buf, BUFSIZE)) {
 				if (debug)
 					printf("Using Negotiation ...\n");
 

--- a/forward.c
+++ b/forward.c
@@ -98,7 +98,7 @@ rr_data_t pac_forward_request(void *thread_data, rr_data_t request, plist_t prox
 			if (debug)
 				printf("\n~~~~~~~ (%d/%d) PAC PROXY %s:%d ~~~~~~~\n", parent_curr, parent_count, aux->hostname, aux->port);
 #ifdef ENABLE_KERBEROS
-            curr_proxy = aux;
+			curr_proxy = aux;
 #endif
 			ret = forward_request(thread_data, request, aux);
 		}

--- a/forward.c
+++ b/forward.c
@@ -57,7 +57,7 @@ int single_proxy_connect(proxy_t *proxy) {
 
 	if (aux->resolved == 0) {
 		if (debug)
-			syslog(LOG_INFO, "Resolving proxy %s...\n", aux->hostname);
+			printf("Resolving proxy %s...\n", aux->hostname);
 		if (so_resolv(&aux->addresses, aux->hostname, aux->port)) {
 			aux->resolved = 1;
 		} else {
@@ -98,7 +98,7 @@ rr_data_t pac_forward_request(void *thread_data, rr_data_t request, plist_t prox
 			if (debug)
 				printf("\n~~~~~~~ (%d/%d) PAC PROXY %s:%d ~~~~~~~\n", parent_curr, parent_count, aux->hostname, aux->port);
 #ifdef ENABLE_KERBEROS
-                        curr_proxy = aux;
+            curr_proxy = aux;
 #endif
 			ret = forward_request(thread_data, request, aux);
 		}
@@ -148,7 +148,7 @@ int proxy_connect(struct auth_s *credentials) {
 		pthread_mutex_unlock(&parent_mtx);
 		if (aux->resolved == 0) {
 			if (debug)
-				syslog(LOG_INFO, "Resolving proxy %s...\n", aux->hostname);
+				printf("Resolving proxy %s...\n", aux->hostname);
 			if (so_resolv(&aux->addresses, aux->hostname, aux->port)) {
 				aux->resolved = 1;
 			} else {
@@ -469,7 +469,7 @@ rr_data_t forward_request(void *thread_data, rr_data_t request) {
 	int sd;
 	assert(thread_data != NULL);
 	int cd = ((struct thread_arg_s *)thread_data)->fd;
-	char saddr[INET6_ADDRSTRLEN];
+	char saddr[INET6_ADDRSTRLEN] = {0};
 	INET_NTOP(&((struct thread_arg_s *)thread_data)->addr, saddr, INET6_ADDRSTRLEN);
 
 beginning:
@@ -623,9 +623,7 @@ beginning:
 				hlist_dump(data[loop]->headers);
 
 			if (loop == 0 && data[0]->req) {
-				if (request_logging_level == 1) {
-					syslog(LOG_DEBUG, "%s %s %s", saddr, data[0]->method, data[0]->url);
-				}
+				syslog(LOG_DEBUG, "%s %s %s", saddr, data[0]->method, data[0]->url);
 			}
 
 shortcut:
@@ -980,7 +978,7 @@ void forward_tunnel(void *thread_data) {
 	assert(thread_data != NULL);
 	int cd = ((struct thread_arg_s *)thread_data)->fd;
 	char *thost = ((struct thread_arg_s *)thread_data)->target;
-	char saddr[INET6_ADDRSTRLEN];
+	char saddr[INET6_ADDRSTRLEN] = {0};
 	INET_NTOP(&((struct thread_arg_s *)thread_data)->addr, saddr, INET6_ADDRSTRLEN);
 
 	tcreds = new_auth();

--- a/kerberos.c
+++ b/kerberos.c
@@ -91,15 +91,15 @@ static void display_status_1(char *m, OM_uint32 code, int type) {
 		maj_stat = gss_display_status(&min_stat, code, type, GSS_C_NULL_OID,
 				&msg_ctx, &msg);
 		if (maj_stat == GSS_S_COMPLETE)
-			syslog(LOG_ERR, "GSS-API error %s: %s\n", m, (char *) msg.value);
+			syslog(LOG_DEBUG, "GSS-API error %s: %s\n", m, (char *) msg.value);
 		else if (maj_stat == GSS_S_BAD_MECH)
-			syslog(LOG_ERR, "GSS-API error that could not be translated due to a bad mechanism (GSS_S_BAD_MECH)\n");
+			syslog(LOG_DEBUG, "GSS-API error that could not be translated due to a bad mechanism (GSS_S_BAD_MECH)\n");
 		else if (maj_stat == GSS_S_BAD_STATUS)
-			syslog(LOG_ERR, "GSS-API error that is unknown (or this function was called with a wrong status type) (GSS_S_BAD_STATUS)\n");
+			syslog(LOG_DEBUG, "GSS-API error that is unknown (or this function was called with a wrong status type) (GSS_S_BAD_STATUS)\n");
 		else if (maj_stat == GSS_S_FAILURE)
-			syslog(LOG_ERR, "GSS-API error and gss_display_status failed with minor status code %lo (GSS_S_FAILURE)\n", (long unsigned int)min_stat);
+			syslog(LOG_DEBUG, "GSS-API error and gss_display_status failed with minor status code %lo (GSS_S_FAILURE)\n", (long unsigned int)min_stat);
 		else
-			syslog(LOG_ERR, "GSS-API error unrecognized return value from gss_display_status\n");
+			syslog(LOG_DEBUG, "GSS-API error unrecognized return value from gss_display_status\n");
 		(void) gss_release_buffer(&min_stat, &msg);
 
 		if (!msg_ctx)

--- a/kerberos.c
+++ b/kerberos.c
@@ -68,17 +68,17 @@
 
 void display_ctx_flags(OM_uint32 flags) {
 	if (flags & GSS_C_DELEG_FLAG)
-		syslog(LOG_INFO, "context flag: GSS_C_DELEG_FLAG\n");
+		printf("context flag: GSS_C_DELEG_FLAG\n");
 	if (flags & GSS_C_MUTUAL_FLAG)
-		syslog(LOG_INFO, "context flag: GSS_C_MUTUAL_FLAG\n");
+		printf("context flag: GSS_C_MUTUAL_FLAG\n");
 	if (flags & GSS_C_REPLAY_FLAG)
-		syslog(LOG_INFO, "context flag: GSS_C_REPLAY_FLAG\n");
+		printf("context flag: GSS_C_REPLAY_FLAG\n");
 	if (flags & GSS_C_SEQUENCE_FLAG)
-		syslog(LOG_INFO, "context flag: GSS_C_SEQUENCE_FLAG\n");
+		printf("context flag: GSS_C_SEQUENCE_FLAG\n");
 	if (flags & GSS_C_CONF_FLAG)
-		syslog(LOG_INFO, "context flag: GSS_C_CONF_FLAG\n");
+		printf("context flag: GSS_C_CONF_FLAG\n");
 	if (flags & GSS_C_INTEG_FLAG)
-		syslog(LOG_INFO, "context flag: GSS_C_INTEG_FLAG\n");
+		printf("context flag: GSS_C_INTEG_FLAG\n");
 }
 
 static void display_status_1(char *m, OM_uint32 code, int type) {
@@ -142,7 +142,7 @@ void display_name(char* txt, gss_name_t *name) {
 		display_status("Display name", maj_stat, min_stat);
 	}
 
-	syslog(LOG_INFO, txt, (char *) out_name.value);
+	printf(txt, (char *) out_name.value);
 
 	(void) gss_release_buffer(&min_stat, &out_name);
 
@@ -161,7 +161,7 @@ int acquire_name(gss_name_t *target_name, char *service_name, gss_OID oid) {
 
 	if (maj_stat != GSS_S_COMPLETE) {
 		display_status("Parsing name", maj_stat, min_stat);
-	} else if (debug){
+	} else if (debug) {
 		display_name("Acquired kerberos name %s\n", target_name);
 	}
 	return maj_stat;
@@ -232,7 +232,7 @@ int client_establish_context(char *service_name,
 	}
 
 	if (debug)
-		syslog(LOG_INFO, "Got token (size=%d)\n", (int) send_tok->length);
+		printf("Got token (size=%d)\n", (int) send_tok->length);
 
 	maj_stat = gss_delete_sec_context(&min_stat, &gss_context, GSS_C_NO_BUFFER);
 	if (maj_stat != GSS_S_COMPLETE) {
@@ -253,8 +253,7 @@ int acquire_kerberos_token(proxy_t* proxy, struct auth_s *credentials,
 
 	if (credentials->haskrb == KRB_KO) {
 		if (debug)
-			syslog(LOG_INFO, "Skipping already failed gss auth for %s\n",
-					proxy->hostname);
+			printf("Skipping already failed gss auth for %s\n", proxy->hostname);
 		return 0;
 	}
 
@@ -263,7 +262,7 @@ int acquire_kerberos_token(proxy_t* proxy, struct auth_s *credentials,
 		if (!(credentials->haskrb & KRB_CREDENTIAL_AVAILABLE)){
 			//no credential -> no token
 			if (debug)
-				syslog(LOG_INFO, "No valid credential available\n");
+				printf("No valid credential available\n");
 			return 0;
 		}
 	}
@@ -283,7 +282,7 @@ int acquire_kerberos_token(proxy_t* proxy, struct auth_s *credentials,
 				BUFSIZE);
 
 		if (debug) {
-			syslog(LOG_INFO, "Token B64 (size=%d)... %s\n",
+			printf("Token B64 (size=%d)... %s\n",
 					(int) strlen(token), token);
 			display_ctx_flags(ret_flags);
 		}
@@ -296,7 +295,7 @@ int acquire_kerberos_token(proxy_t* proxy, struct auth_s *credentials,
 		credentials->haskrb = KRB_KO;
 
 		if (debug)
-			syslog(LOG_INFO, "No valid token acquired for %s\n", service_name);
+			printf("No valid token acquired for %s\n", service_name);
 
 		rc=0;
 	}
@@ -326,7 +325,8 @@ int check_credential() {
 	(void) gss_release_oid_set(&min_stat, &mechanisms);
 
 	if (name != NULL) {
-		display_name("Available cached credential %s\n", &name);
+		if (debug)
+			display_name("Available cached credential %s\n", &name);
 		(void) gss_release_name(&min_stat, &name);
 		return KRB_CREDENTIAL_AVAILABLE;
 	}

--- a/kerberos.h
+++ b/kerberos.h
@@ -43,7 +43,7 @@
 /**
  * acquires a kerberos token for default credential using SPN HTTP@<thost>
  */
-int acquire_kerberos_token(proxy_t* proxy, struct auth_s *credentials, char* buf);
+int acquire_kerberos_token(proxy_t* proxy, struct auth_s *credentials, char* buf, size_t bufsize);
 
 /**
  * checks if a default cached credential is cached

--- a/main.c
+++ b/main.c
@@ -608,6 +608,8 @@ void *socks5_thread(void *thread_data) {
 	int open = !hlist_count(users_list);
 
 	int cd = ((struct thread_arg_s *)thread_data)->fd;
+	char saddr[INET6_ADDRSTRLEN];
+	INET_NTOP(&((struct thread_arg_s *)thread_data)->addr, saddr, INET6_ADDRSTRLEN);
 	free(thread_data);
 
 	/*
@@ -842,6 +844,7 @@ void *socks5_thread(void *thread_data) {
 		}
 	}
 
+	syslog(LOG_DEBUG, "%s SOCKS %s", saddr, thost);
 
 	/*
 	 * Let's give them bi-directional connection they asked for

--- a/main.c
+++ b/main.c
@@ -83,13 +83,6 @@
  */
 int debug = 0;					/* all debug printf's and possibly external modules */
 
-/**
- * Values and their meaning:
- * 0 - no requests are logged - default
- * 1 - requests are logged (old behavior)
- */
-int request_logging_level = 0;
-
 struct auth_s *g_creds = NULL;			/* throughout the whole module */
 
 int quit = 0;					/* sighandler() */
@@ -282,6 +275,7 @@ plist_t pac_create_list(plist_t paclist, char *pacp_str) {
  */
 void listen_add(const char *service, plist_t *list, char *spec, int gateway) {
 	struct addrinfo *addresses;
+	int i;
 	int p;
 	int port;
 	char *tmp;
@@ -311,7 +305,10 @@ void listen_add(const char *service, plist_t *list, char *spec, int gateway) {
 		so_resolv_wildcard(&addresses, port, gateway);
 	}
 
-	so_listen(list, addresses, NULL);
+	i = so_listen(list, addresses, NULL);
+	if (i == 0) {
+		syslog(LOG_INFO, "New %s service on %s\n", service, spec);
+	}
 	freeaddrinfo(addresses);
 }
 
@@ -608,7 +605,7 @@ void *socks5_thread(void *thread_data) {
 	int open = !hlist_count(users_list);
 
 	int cd = ((struct thread_arg_s *)thread_data)->fd;
-	char saddr[INET6_ADDRSTRLEN];
+	char saddr[INET6_ADDRSTRLEN] = {0};
 	INET_NTOP(&((struct thread_arg_s *)thread_data)->addr, saddr, INET6_ADDRSTRLEN);
 	free(thread_data);
 
@@ -930,7 +927,8 @@ int main(int argc, char **argv) {
 	cuid = zmalloc(MINIBUF_SIZE);
 	cauth = zmalloc(MINIBUF_SIZE);
 
-	openlog("cntlm", LOG_CONS, LOG_DAEMON);
+	int syslog_debug = 0;
+	openlog("cntlm", LOG_CONS | LOG_PERROR, LOG_DAEMON);
 
 #if config_endian == 0
 	syslog(LOG_INFO, "Starting cntlm version " VERSION " for BIG endian\n");
@@ -938,7 +936,7 @@ int main(int argc, char **argv) {
 	syslog(LOG_INFO, "Starting cntlm version " VERSION " for LITTLE endian\n");
 #endif
 
-	while ((i = getopt(argc, argv, ":-:T:a:c:d:fghIl:p:r:su:vw:x:BF:G:HL:M:N:O:P:R:S:U:X:q:")) != -1) {
+	while ((i = getopt(argc, argv, ":-:T:a:c:d:fghIl:p:r:su:vw:x:BF:G:HL:M:N:O:P:R:S:U:X:q")) != -1) {
 		switch (i) {
 			case 'a':
 				strlcpy(cauth, optarg, MINIBUF_SIZE);
@@ -1059,9 +1057,9 @@ int main(int argc, char **argv) {
 				break;
 			case 'T':
 				debug = 1;
+				syslog_debug = 1;
 				asdaemon = 0;
 				tracefile = open(optarg, O_CREAT | O_TRUNC | O_WRONLY, 0600);
-				openlog("cntlm", LOG_CONS | LOG_PERROR, LOG_DAEMON);
 				if (tracefile < 0) {
 					fprintf(stderr, "Cannot create trace file.\n");
 					myexit(1);
@@ -1085,8 +1083,8 @@ int main(int argc, char **argv) {
 				break;
 			case 'v':
 				debug = 1;
+				syslog_debug = 1;
 				asdaemon = 0;
-				openlog("cntlm", LOG_CONS | LOG_PERROR, LOG_DAEMON);
 				break;
 			case 'w':
 				strlcpy(cworkstation, optarg, MINIBUF_SIZE);
@@ -1103,15 +1101,7 @@ int main(int argc, char **argv) {
 #endif
 				break;
 			case 'q':
-				if (*optarg == '0') {
-					request_logging_level = 0;
-				}
-				else if (*optarg == '1') {
-					request_logging_level = 1;
-				}
-				else {
-					fprintf(stderr, "Invalid argument for option -q, using default value of %d.\n", request_logging_level);
-				}
+				syslog_debug = 1;
 				break;
 			case 'h':
 				help = 1;
@@ -1181,11 +1171,7 @@ int main(int argc, char **argv) {
 				"\t    Create a PID file upon successful start.\n");
 		fprintf(stream, "\t-p  <password>\n"
 				"\t    Account password. Will not be visible in \"ps\", /proc, etc.\n");
-		fprintf(stream, "\t-q  <level>\n"
-				"\t    Controls logging of requests like CONNECT/GET with URL.\n"
-				"\t    level can be:\n"
-				"\t    0 no requests are logged - default\n"
-				"\t    1 requests are logged (old behavior)\n");
+		fprintf(stream, "\t-q  Sets the Syslog logging level to DEBUG (default level is INFO).\n");
 		fprintf(stream, "\t-R  <username>:<password>\n"
 				"\t    Enable authorization for SOCKS5 proxy, when enabled.\n"
 				"\t    It can be used several times, to create a whole list of accounts.\n");
@@ -1271,7 +1257,7 @@ int main(int argc, char **argv) {
 			if (cf)
 				printf("Default config file opened successfully\n");
 			else
-				syslog(LOG_ERR, "Could not open default config file\n");
+				printf("Could not open default config file\n");
 		}
 	}
 #endif
@@ -1748,6 +1734,12 @@ int main(int argc, char **argv) {
 	} else {
 		openlog("cntlm", LOG_CONS | LOG_PID | LOG_PERROR, LOG_DAEMON);
 		syslog(LOG_INFO, "Cntlm ready, staying in the foreground");
+	}
+
+	if (syslog_debug) {
+		setlogmask(LOG_UPTO(LOG_DEBUG));
+	} else {
+		setlogmask(LOG_UPTO(LOG_INFO));
 	}
 
 #ifdef ENABLE_KERBEROS

--- a/main.c
+++ b/main.c
@@ -214,8 +214,7 @@ plist_t pac_create_list(plist_t paclist, char *pacp_str) {
 	/* Make a copy of shared PAC string pacp_str (coming
 	 * from pacparser) to avoid manipulation by strsep.
 	 */
-	pacp_tmp = zmalloc(sizeof(char) * strlen(pacp_str) + 1);
-	strcpy(pacp_tmp, pacp_str);
+	pacp_tmp = strdup(pacp_str);
 
 	cur_proxy = strsep(&pacp_tmp, ";");
 

--- a/utils.h
+++ b/utils.h
@@ -121,6 +121,13 @@ struct thread_arg_s {
 	(inet_ntop(((struct sockaddr*)(sa))->sa_family, \
 		((struct sockaddr*)(sa))->sa_family == AF_INET ? (void*)&((struct sockaddr_in*)(sa))->sin_addr : (void*)&((struct sockaddr_in6*)(sa))->sin6_addr, (s), (len)))
 
+/*
+ * Returns the port of an inet or inet6 address (determined by the family).
+ * (sa) must be a pointer to sockaddr_in or sockaddr_in6.
+ */
+#define INET_PORT(sa) \
+	(((struct sockaddr*)(sa))->sa_family == AF_INET ? ((struct sockaddr_in*)(sa))->sin_port : ((struct sockaddr_in6*)(sa))->sin6_port)
+
 extern void myexit(int rc) __attribute__((noreturn));
 extern void croak(const char *msg, const int console) __attribute__((noreturn));
 

--- a/utils.h
+++ b/utils.h
@@ -111,6 +111,16 @@ struct thread_arg_s {
 	struct sockaddr_in6 addr;
 };
 
+/*
+ * Returns the string representation of an inet or inet6 address (determined by the family).
+ * (sa) must be a pointer to sockaddr_in or sockaddr_in6.
+ * (s) must be a char array of at least INET6_ADDRSTRLEN size.
+ * (len) is the length of (s).
+ */
+#define INET_NTOP(sa, s, len)	\
+	(inet_ntop(((struct sockaddr*)(sa))->sa_family, \
+		((struct sockaddr*)(sa))->sa_family == AF_INET ? (void*)&((struct sockaddr_in*)(sa))->sin_addr : (void*)&((struct sockaddr_in6*)(sa))->sin6_addr, (s), (len)))
+
 extern void myexit(int rc) __attribute__((noreturn));
 extern void croak(const char *msg, const int console) __attribute__((noreturn));
 


### PR DESCRIPTION
Hello, commit 084d75ba accidentally removed _syslog_ debug messages of incoming connections. This, among other things, made the "-q" command line argument useless.
I need to activate _syslogs_ of connections for debugging purposes, so this PR solves this.

The option "-q" (that now does not need an additional parameter) sets the _syslog_ log level to `LOG_DEBUG` otherwise the default is `LOG_INFO`.
```
if (syslog_debug) {
	setlogmask(LOG_UPTO(LOG_DEBUG));
} else {
	setlogmask(LOG_UPTO(LOG_INFO));
}

```
Also, all loggings activated by the `debug` flag are `printf` since those are needed for tracing purposes. So that _syslogs_ are for normal executions and _printf_ are for tracing/debugging executions.
Finally, kerberos can be very verbose logging as errors non blocking problems. I changed those _syslogs_ to LOG_DEBUG.