### PR TITLE
Improvements

### DIFF
--- a/config.c
+++ b/config.c
@@ -123,7 +123,7 @@ config_t config_open(const char *fname) {
 		char * value = substr(buf, j, i-j);
 		if (!quote) {
 			i = strcspn(value, "#");
-			if (i != strlen(value))
+			if (i != (int)strlen(value))
 				value[i] = 0;
 			trimr(value);
 		}

--- a/http.c
+++ b/http.c
@@ -57,7 +57,7 @@ char *get_http_header_name(const char *src) {
 	int i;
 
 	i = strcspn(src, ":");
-	if (i != strlen(src))
+	if (i != (int)strlen(src))
 		return substr(src, 0, i);
 	else
 		return NULL;
@@ -236,7 +236,7 @@ int headers_recv(int fd, rr_data_t data) {
 			if (*(tok+1) == ':') {
 				data->port = atoi(tok+2);
 			}
-		} else if (tok = strchr(host, ':')) {
+		} else if ((tok = strchr(host, ':'))) {
 			*tok = 0;
 			data->hostname = strdup(host);
 			data->port = atoi(tok+1);
@@ -530,7 +530,7 @@ length_t http_has_body(rr_data_const_t request, rr_data_const_t response) {
 
 	if (current == NULL) {
 		syslog(LOG_ERR, "Internal error in function http_has_body(): Both arguments to function seem to be invalid/NULL: request: %p response: %p\n",
-				request, response);
+				(const void *)request, (const void *)response);
 		return 0;
 	}
 

--- a/kerberos.c
+++ b/kerberos.c
@@ -141,7 +141,7 @@ void display_name(char* txt, gss_name_t *name) {
 		display_status("Display name", maj_stat, min_stat);
 	}
 
-	printf("%s %s\n", txt, out_name.value);
+	printf("%s %s\n", txt, (char *)out_name.value);
 
 	(void) gss_release_buffer(&min_stat, &out_name);
 

--- a/main.c
+++ b/main.c
@@ -162,7 +162,7 @@ int parent_add(const char *parent, int port) {
 	const char *q = strrchr(spec, ':');
 	if (q != NULL || !port) {
 		int p;
-		p = (q != NULL) ? (int)(q - spec) : strlen(spec);
+		p = (q != NULL) ? (int)(q - spec) : (int)strlen(spec);
 
 		if(spec[0] == '[' && spec[p-1] == ']') {
 			tmp = substr(spec, 1, p-2);

--- a/main.c
+++ b/main.c
@@ -480,7 +480,7 @@ void *proxy_thread(void *thread_data) {
 					pacp_str = pacparser_find_proxy(request->url, request->hostname);
 					pthread_mutex_unlock(&pacparser_mtx);
 
-					plist_free(pac_list);
+					proxylist_free(pac_list);
 					pac_list = NULL;
 					pac_list = pac_create_list(pac_list, pacp_str);
 				}
@@ -526,7 +526,7 @@ void *proxy_thread(void *thread_data) {
 #endif
 
 #ifdef ENABLE_PACPARSER
-	plist_free(pac_list);
+	proxylist_free(pac_list);
 #endif
 	free(thread_data);
 	close(cd);
@@ -2013,7 +2013,7 @@ bailout:
 	free(magic_detect);
 	free(g_creds);
 
-	parentlist_free(parent_list);
+	proxylist_free(parent_list);
 
 	exit(0);
 }

--- a/utils.c
+++ b/utils.c
@@ -156,7 +156,7 @@ void plist_dump(plist_const_t list) {
 /*
  * Return the pointer associated with the key.
  */
-char *plist_get(plist_const_t list, const int key) {
+char *plist_get(plist_const_t list, const unsigned long key) {
 	plist_const_t t = list;
 
 	while (t) {
@@ -525,7 +525,7 @@ char *substr(const char *src, int pos, int len) {
 	if (len == 0)
 		len = strlen(src);
 
-	min_len = MIN(len, strlen(src)-pos);
+	min_len = MIN(len, (int)strlen(src)-pos);
 	if (min_len <= 0)
 		return zmalloc(1);
 

--- a/utils.c
+++ b/utils.c
@@ -254,9 +254,9 @@ plist_t plist_free(plist_t list) {
 }
 
 /*
- * Free parent_list
+ * Free the list of proxy_t data.
  */
-plist_t parentlist_free(plist_t list) {
+plist_t proxylist_free(plist_t list) {
 	while (list) {
 		plist_t t = list->next;
 

--- a/utils.h
+++ b/utils.h
@@ -135,7 +135,7 @@ extern plist_t plist_add(plist_t list, unsigned long key, void *aux);
 extern plist_t plist_del(plist_t list, const unsigned long key);
 extern int plist_in(plist_const_t list, const unsigned long key) __attribute__((warn_unused_result));
 extern void plist_dump(plist_const_t list);
-extern char *plist_get(plist_const_t list, const int key) __attribute__((warn_unused_result));
+extern char *plist_get(plist_const_t list, const unsigned long key) __attribute__((warn_unused_result));
 extern int plist_pop(plist_t *list, void **aux);
 extern int plist_count(plist_const_t list) __attribute__((warn_unused_result));
 extern plist_t plist_free(plist_t list);

--- a/utils.h
+++ b/utils.h
@@ -139,7 +139,7 @@ extern char *plist_get(plist_const_t list, const int key) __attribute__((warn_un
 extern int plist_pop(plist_t *list, void **aux);
 extern int plist_count(plist_const_t list) __attribute__((warn_unused_result));
 extern plist_t plist_free(plist_t list);
-extern plist_t parentlist_free(plist_t list);
+extern plist_t proxylist_free(plist_t list);
 
 extern hlist_t hlist_add(hlist_t list, char *key, char *value, hlist_add_t allockey, hlist_add_t allocvalue);
 extern hlist_t hlist_dup(hlist_const_t list) __attribute__((warn_unused_result));


### PR DESCRIPTION
This PR improves various stuff.

- fix a memory leak in pac parser logic where `addrinfo` structures were net freed with `freeaddrinfo()` when freeing the list of proxy data
- kerberos logic can log non blocking errors very often, that are not very useful in normal execution, so it's better to log them in verbose (aka debug) mode. So we can also avoid the boilerplate required to prepare the gss log message;
- finally, some fixes to remove many compiler warnings

These commits represent different units of work so it should be better not to squash them.