### PR TITLE
fix memory leaks

### DIFF
--- a/auth.c
+++ b/auth.c
@@ -46,6 +46,9 @@ struct auth_s *new_auth(void) {
 	tmp->hashnt = 0;
 	tmp->hashlm = 0;
 	tmp->flags = 0;
+#ifdef ENABLE_KERBEROS
+	tmp->haskrb = 0;
+#endif
 
 	return tmp;
 }

--- a/forward.c
+++ b/forward.c
@@ -145,7 +145,6 @@ int proxy_connect(struct auth_s *credentials) {
 	do {
 		pthread_mutex_lock(&parent_mtx);
 		aux = (proxy_t *)plist_get(parent_list, parent_curr);
-		pthread_mutex_unlock(&parent_mtx);
 		if (aux->resolved == 0) {
 			if (debug)
 				printf("Resolving proxy %s...\n", aux->hostname);
@@ -155,6 +154,7 @@ int proxy_connect(struct auth_s *credentials) {
 				syslog(LOG_ERR, "Cannot resolve proxy %s\n", aux->hostname);
 			}
 		}
+		pthread_mutex_unlock(&parent_mtx);
 
 		i = -1;
 		if (aux->resolved != 0)

--- a/main.c
+++ b/main.c
@@ -206,6 +206,7 @@ int parent_add(const char *parent, int port) {
 plist_t pac_create_list(plist_t paclist, char *pacp_str) {
 	int paclist_count = 0;
 	char *pacp_tmp = NULL;
+	char *pacp_start = NULL;
 	char *cur_proxy = NULL;
 
 	if (pacp_str == NULL) {
@@ -216,7 +217,8 @@ plist_t pac_create_list(plist_t paclist, char *pacp_str) {
 	/* Make a copy of shared PAC string pacp_str (coming
 	 * from pacparser) to avoid manipulation by strsep.
 	 */
-	pacp_tmp = strdup(pacp_str);
+	pacp_start = strdup(pacp_str);
+	pacp_tmp = pacp_start; // save the pointer to this buffer so we can free it
 
 	cur_proxy = strsep(&pacp_tmp, ";");
 
@@ -265,7 +267,7 @@ plist_t pac_create_list(plist_t paclist, char *pacp_str) {
 		plist_dump(paclist);
 	}
 
-	free(pacp_tmp);
+	free(pacp_start);
 
 	return paclist;
 }


### PR DESCRIPTION
Hello,
I ran the program with _valgrind_ memory leaks checker and found some leaks, due to concurrent manipulation of pointers and wrong manipulation of a string pointer, and also uninitialised data.
This PR fixes these.
There is also a memory leak in the pacparser library and there is already an open issue and a pr for it.
