### PR TITLE
keep default domain if not passed during basic authentication

### DIFF
--- a/http.c
+++ b/http.c
@@ -675,7 +675,6 @@ int http_parse_basic(hlist_const_t headers, const char *header, struct auth_s *t
 		*pos = 0;
 		dom = strchr(buf, '\\');
 		if (dom == NULL) {
-			auth_strcpy(tcreds, domain, "");
 			auth_strcpy(tcreds, user, buf);
 		} else {
 			*dom = 0;


### PR DESCRIPTION
Documentation states this:
```
-B    (NTLMToBasic)
              This option enables "NTLM-to-basic", which allows you to use one cntlm for multiple users. Please note that all security of NTLM is lost this
              way. Basic auth uses just a simple encoding algorithm to "hide" your credentials and it is moderately easy to sniff them.

              IMPORTANT: HTTP protocol obviously has means to negotiate authorization before letting you through, but TCP/IP doesn't (i.e. open port is
              open port). If you use NTLM-to-basic and DON'T specify some username/password in the configuration file, you are bound to loose tunneling
              features, because cntlm alone won't know your credentials.

              Because NTLM identification has at least three parts (username, password, domain) and the basic authentication provides fields for only two
              (username, password), you have to smuggle the domain part somewhere. You can set the Domain config/cmd-line parameter, which will then be
              used for all users, who don't specify their domain as a part of the username. To do that and override the global domain setting, use this
              instead of plain username in the password dialog: "domain\username".
```
But now if the domain is not passed along with basic authentication credentials, it is left blank, and the ntlm negotiation fails.
This PR restores the original behaviour.
