### PR TITLE
Restore ACL support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,9 @@ else
 endif
 
 ifneq ($(findstring CYGWIN,$(OS)),)
-	OBJS=utils.o ntlm.o xcrypt.o config.o socket.o auth.o http.o forward.o direct.o scanner.o pages.o main.o sspi.o win/resources.o
+	OBJS=utils.o ntlm.o xcrypt.o config.o socket.o acl.o auth.o http.o forward.o direct.o scanner.o pages.o main.o sspi.o win/resources.o
 else
-	OBJS=utils.o ntlm.o xcrypt.o config.o socket.o auth.o http.o forward.o direct.o scanner.o pages.o main.o
+	OBJS=utils.o ntlm.o xcrypt.o config.o socket.o acl.o auth.o http.o forward.o direct.o scanner.o pages.o main.o
 endif
 
 ENABLE_KERBEROS=$(shell grep -c ENABLE_KERBEROS config/config.h)

--- a/Makefile.clang
+++ b/Makefile.clang
@@ -32,9 +32,9 @@ else
 endif
 
 ifneq ($(findstring CYGWIN,$(OS)),)
-	OBJS=utils.o ntlm.o xcrypt.o config.o socket.o auth.o http.o forward.o direct.o scanner.o pages.o main.o sspi.o win/resources.o
+	OBJS=utils.o ntlm.o xcrypt.o config.o socket.o acl.o auth.o http.o forward.o direct.o scanner.o pages.o main.o sspi.o win/resources.o
 else
-	OBJS=utils.o ntlm.o xcrypt.o config.o socket.o auth.o http.o forward.o direct.o scanner.o pages.o main.o
+	OBJS=utils.o ntlm.o xcrypt.o config.o socket.o acl.o auth.o http.o forward.o direct.o scanner.o pages.o main.o
 endif
 
 ENABLE_KERBEROS=$(shell grep -c ENABLE_KERBEROS config/config.h)

--- a/Makefile.ikos-scan-cc
+++ b/Makefile.ikos-scan-cc
@@ -33,9 +33,9 @@ else
 endif
 
 ifneq ($(findstring CYGWIN,$(OS)),)
-	OBJS=utils.o ntlm.o xcrypt.o config.o socket.o auth.o http.o forward.o direct.o scanner.o pages.o main.o sspi.o win/resources.o
+	OBJS=utils.o ntlm.o xcrypt.o config.o socket.o acl.o auth.o http.o forward.o direct.o scanner.o pages.o main.o sspi.o win/resources.o
 else
-	OBJS=utils.o ntlm.o xcrypt.o config.o socket.o auth.o http.o forward.o direct.o scanner.o pages.o main.o
+	OBJS=utils.o ntlm.o xcrypt.o config.o socket.o acl.o auth.o http.o forward.o direct.o scanner.o pages.o main.o
 endif
 
 $(NAME): configure-stamp $(OBJS)

--- a/Makefile.xlc
+++ b/Makefile.xlc
@@ -9,7 +9,7 @@ MANDIR=/usr/local/man
 #
 #
 CC=xlc_r
-OBJS=utils.o ntlm.o xcrypt.o config.o socket.o auth.o http.o forward.o direct.o scanner.o pages.o main.o sspi.o
+OBJS=utils.o ntlm.o xcrypt.o config.o socket.o acl.o auth.o http.o forward.o direct.o scanner.o pages.o main.o sspi.o
 CFLAGS=$(FLAGS) -O3 -D_POSIX_C_SOURCE=200112 -D_ISOC99_SOURCE -D_REENTRANT -DVERSION=\"`cat VERSION`\"
 LDFLAGS=-lpthread
 NAME=cntlm

--- a/acl.c
+++ b/acl.c
@@ -1,0 +1,137 @@
+/*
+ * These are ACL routines for the main module of CNTLM
+ *
+ * CNTLM is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * CNTLM is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * St, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2007 David Kubicek
+ *
+ */
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <syslog.h>
+#include <string.h>
+#include <stdlib.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include "acl.h"
+#include "socket.h"
+#include "swap.h"
+
+/*
+ * TODO: retest ACLs on big-endian
+ */
+
+/*
+ * Add the rule spec to the ACL list.
+ */
+int acl_add(plist_t *rules, char *spec, enum acl_t acl) {
+	struct addrinfo *addresses = NULL, *p;
+	struct sockaddr_in *naddr = NULL;
+	network_t *aux;
+	int mask = 32;
+	size_t i;
+	char *tmp;
+
+	if (rules == NULL)
+		return 0;
+
+	spec = strdup(spec);
+	aux = (network_t *)zmalloc(sizeof(network_t));
+	i = strcspn(spec, "/");
+	if (i < strlen(spec)) {
+		spec[i] = 0;
+		mask = strtol(spec+i+1, &tmp, 10);
+		if (mask < 0 || mask > 32 || spec[i+1] == 0 || *tmp != 0) {
+			syslog(LOG_ERR, "ACL netmask for %s is invalid\n", spec);
+			free(aux);
+			free(spec);
+			return 0;
+		}
+	}
+
+	if (!strcmp("*", spec)) {
+		aux->ip = 0;
+		mask = 0;
+	} else if (!strcmp("0", spec)) {
+		aux->ip = 0;
+	} else if (!so_resolv(&addresses, spec, 0)) {
+		syslog(LOG_ERR, "ACL source address %s is invalid\n", spec);
+		free(aux);
+		free(spec);
+		return 0;
+	}
+
+	if (addresses != NULL) {
+		// TODO only ipv4 client addresses are supported for now
+		for (p = addresses; p != NULL; p = p->ai_next) {
+			if (p->ai_family == AF_INET) {
+				naddr = (struct sockaddr_in*)p->ai_addr;
+				break;
+			}
+		}
+
+		if (naddr == NULL) {
+			syslog(LOG_ERR, "ACL only ipv4 source addresses are supported (%s)\n", spec);
+			free(aux);
+			free(spec);
+			freeaddrinfo(addresses);
+			return 0;
+		}
+
+		aux->ip = naddr->sin_addr.s_addr;
+	}
+
+	aux->mask = mask;
+	mask = swap32(~(((uint64_t)1 << (32-mask)) - 1));
+	if ((aux->ip & mask) != aux->ip)
+		syslog(LOG_WARNING, "Subnet definition might be incorrect: %s/%d\n", naddr ? inet_ntoa(naddr->sin_addr) : spec, aux->mask);
+
+	syslog(LOG_INFO, "New ACL rule: %s %s/%d\n", (acl == ACL_ALLOW ? "allow" : "deny"), naddr ? inet_ntoa(naddr->sin_addr) : spec, aux->mask);
+	*rules = plist_add(*rules, acl, (char *)aux);
+
+	free(spec);
+	freeaddrinfo(addresses);
+	return 1;
+}
+
+/*
+ * Takes client IP address (network order) and walks the
+ * ACL rules until a match is found, returning ACL_ALLOW
+ * or ACL_DENY accordingly. If no rule matches, connection
+ * is allowed (such is the case with no ACLs).
+ *
+ * Proper policy should always end with a default rule,
+ * targeting either "*" or "0/0" to explicitly express
+ * one's intentions.
+ */
+enum acl_t acl_check(plist_const_t rules, struct sockaddr *caddr) {
+	// TODO only ipv4 client addresses are supported for now
+	if (rules && caddr->sa_family == AF_INET) {
+		struct sockaddr_in* naddr = (struct sockaddr_in*)caddr;
+		while (rules) {
+			const network_t * const aux = (network_t *)rules->aux;
+			const unsigned int mask = swap32(~(((uint64_t)1 << (32-aux->mask)) - 1));
+
+			if ((naddr->sin_addr.s_addr & mask) == (aux->ip & mask))
+				return rules->key;
+
+			rules = rules->next;
+		}
+	}
+
+	return ACL_ALLOW;
+}

--- a/acl.h
+++ b/acl.h
@@ -1,0 +1,45 @@
+/*
+ * These are ACL routines for the main module of CNTLM
+ *
+ * CNTLM is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * CNTLM is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+ * St, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * Copyright (c) 2007 David Kubicek
+ *
+ */
+
+#ifndef _ACL_H
+#define _ACL_H
+
+#include <netinet/in.h>
+
+#include "utils.h"
+
+/*
+ * ACL rule datatypes.
+ */
+enum acl_t {
+	ACL_ALLOW = 0,
+	ACL_DENY
+};
+
+typedef struct {
+	unsigned int ip;
+	int mask;
+} network_t;
+
+extern int acl_add(plist_t *rules, char *spec, enum acl_t acl);
+extern enum acl_t acl_check(plist_const_t rules, struct sockaddr *caddr);
+
+#endif /* _ACL_H */

--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Depends: adduser, libgssapi-krb5-2, ${misc:Depends}, ${shlibs:Depends}
 Replaces: ntlmaps
 Description: Fast NTLM authentication proxy with tunneling
  Cntlm is a fast and efficient NTLM proxy, with support for TCP/IP tunneling,
- authenticated connection caching, proper daemon logging and behaviour
+ authenticated connection caching, ACLs, proper daemon logging and behaviour
  and much more. It has up to ten times faster responses than similar NTLM
  proxies, while using by orders or magnitude less RAM and CPU. Manual page 
  contains detailed information.

--- a/doc/cntlm.1
+++ b/doc/cntlm.1
@@ -73,7 +73,20 @@ all of its settings.
 
 Use \fB-h\fP to see available options with short description.
 
-.TP 
+.TP
+.B -A IP/mask\ \ \ \ (Allow)
+Allow ACL rule. Together with \fB-D\fP (Deny) they are the two rules allowed in ACL policy. It is more usual
+to have this in a configuration file, but \fBCntlm\fP follows the premise that you can do the same on the
+command-line as you can using the config file. When \fBCntlm\fP receives a connection request, it decides
+whether to allow or deny it. All ACL rules are stored in a list in the same order as specified. \fBCntlm\fP
+then walks the list and the first \fIIP/mask\fP rule that matches the request source address is applied. The
+\fImask\fP can be any number from 0 to 32, where 32 is the default (that is exact IP match). This notation is
+also known as CIDR. If you want to match everything, use \fB0/0\fP or an asterix. ACLs on the command-line
+take precedence over those in the config file. In such case, you will see info about that in the log (among
+the list of unused options). There you can also see warnings about possibly incorrect subnet spec, that's when
+the \fIIP\fP part has more bits than you declare by \fImask\fP (e.g. 10.20.30.40/24 should be 10.20.30.0/24).
+
+.TP
 .B -a NTLMv2 | NTLM2SR | NT | NTLM | LM | GSS\ \ \ \ (Auth)
 Authentication type. NTLM(v2) comprises of one or two hashed responses, NT and LM or NTLM2SR or NTv2 and LMv2,
 which are computed from the password hash. Each response uses a different hashing algorithm; as new response
@@ -119,8 +132,12 @@ username in the password dialog: "domain\\username".
 .TP 
 .B -c <filename>
 Configuration file. Command-line options, if used, override its single options or are added at the top of the
-list for multi options (tunnels, parent proxies, etc).
-Use \fI/dev/null\fP to disable any config file.
+list for multi options (tunnels, parent proxies, etc) with the exception of ACLs, which are completely
+overridden. Use \fI/dev/null\fP to disable any config file.
+
+.TP
+.B -D IP/mask\ \ \ \ (Deny)
+Deny ACL rule. See option \fB-A\fP above.
 
 .TP
 .B -d <domain>\ \ \ \ (Domain)
@@ -362,14 +379,22 @@ pound signs, etc. No escape sequences are allowed in quoted strings.
 
 There are two types of keywords, \fIlocal\fP and \fIglobal\fP. Local options specify authentication details
 per domain (or location). Global keywords apply to all sections and proxies. They should be placed before all
-sections, but it's not necessary. They are: \fCGateway, Listen, SOCKS5Proxy, SOCKS5User,
+sections, but it's not necessary. They are: \fCAllow, Deny, Gateway, Listen, SOCKS5Proxy, SOCKS5User,
 NTLMToBasic, Tunnel\fP.
 
 All available keywords are listed here, full descriptions are in the OPTIONS section:
 
 .TP
+.B Allow <IP>[/<mask>]
+ACL allow rule, see \fB-A\fP.
+
+.TP
 .B Auth NTLMv2 | NTLM2SR | NT | NTLM | LM
 Select any possible combination of NTLM hashes using a single parameter.
+
+.TP
+.B Deny <IP>[/<mask>]
+ACL deny rule, see \fB-A\fP.
 
 .TP
 .B Domain <domain_name>

--- a/doc/cntlm.conf
+++ b/doc/cntlm.conf
@@ -76,6 +76,12 @@ Listen		3128
 #
 #Gateway	yes
 
+# Useful in Gateway mode to allow/restrict certain IPs
+# Specifiy individual IPs or subnets one rule per line.
+#
+#Allow		127.0.0.1
+#Deny		0/0
+
 # GFI WebMonitor-handling plugin parameters, disabled by default
 #
 #ISAScannerSize     1024

--- a/main.c
+++ b/main.c
@@ -1890,7 +1890,7 @@ int main(int argc, char **argv) {
 	 */
 	while (quit == 0 || (tc != tj && quit < 2)) {
 		struct thread_arg_s *data;
-		struct sockaddr_in6 caddr;
+		union sock_addr caddr;
 		struct timeval tv;
 		socklen_t clen;
 		fd_set set;
@@ -1947,7 +1947,7 @@ int main(int argc, char **argv) {
 					continue;
 
 				clen = sizeof(caddr);
-				cd = accept(i, (struct sockaddr *)&caddr, (socklen_t *)&clen);
+				cd = accept(i, &caddr.addr, &clen);
 
 				if (cd < 0) {
 					syslog(LOG_ERR, "Serious error during accept: %s\n", strerror(errno));
@@ -1957,7 +1957,7 @@ int main(int argc, char **argv) {
 				/*
 				 * Check main access control list.
 				 */
-				if (acl_check(rules, (struct sockaddr *)&caddr) != ACL_ALLOW) {
+				if (acl_check(rules, &caddr.addr) != ACL_ALLOW) {
 					char s[INET6_ADDRSTRLEN] = {0};
 					INET_NTOP(&caddr, s, INET6_ADDRSTRLEN);
 					unsigned short port = INET_PORT(&caddr);

--- a/main.c
+++ b/main.c
@@ -1409,8 +1409,8 @@ int main(int argc, char **argv) {
 		if (rules == NULL) {
 			list = cf->options;
 			while (list) {
-				if (!(i=strcasecmp("Allow", list->key)) || !strcasecmp("Deny", list->key))
-					if (!acl_add(&rules, list->value, i ? ACL_DENY : ACL_ALLOW))
+				if ((!(i=strcasecmp("Allow", list->key)) || !strcasecmp("Deny", list->key))
+					&& !acl_add(&rules, list->value, i ? ACL_DENY : ACL_ALLOW))
 						myexit(1);
 				list = list->next;
 			}

--- a/main.c
+++ b/main.c
@@ -310,7 +310,7 @@ void listen_add(const char *service, plist_t *list, char *spec, int gateway) {
 	}
 
 	i = so_listen(list, addresses, NULL);
-	if (i == 0) {
+	if (i > 0) {
 		syslog(LOG_INFO, "New %s service on %s\n", service, spec);
 	}
 	freeaddrinfo(addresses);
@@ -368,7 +368,7 @@ void tunnel_add(plist_t *list, char *spec, int gateway) {
 		strlcat(tmp, field[pos+2], tmp_len);
 
 		i = so_listen(list, addresses, tmp);
-		if (i == 0) {
+		if (i > 0) {
 			syslog(LOG_INFO, "New tunnel to %s\n", tmp);
 		} else {
 			syslog(LOG_ERR, "Unable to bind tunnel");

--- a/rpm/cntlm.spec
+++ b/rpm/cntlm.spec
@@ -27,7 +27,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-root
 
 %description
 Cntlm is a fast and efficient NTLM proxy, with support for TCP/IP tunneling,
-authenticated connection caching, proper daemon logging and behaviour
+authenticated connection caching, ACLs, proper daemon logging and behaviour
 and much more. It has up to ten times faster responses than similar NTLM
 proxies, while using by orders or magnitude less RAM and CPU. Manual page 
 contains detailed information.

--- a/utils.h
+++ b/utils.h
@@ -103,12 +103,22 @@ struct rr_data_s {
 };
 
 /*
+ * This structure can represent a sockaddr or
+ * an AF_INET (ipv4) sockaddr or an AF_INET6 (ipv6) sockaddr
+ */
+union sock_addr {
+	struct sockaddr addr;
+	struct sockaddr_in addr_in;
+	struct sockaddr_in6 addr_in6;
+};
+
+/*
  * This is used in main() for passing arguments to the thread.
  */
 struct thread_arg_s {
 	int fd;
 	char *target;
-	struct sockaddr_in6 addr;
+	union sock_addr addr;
 };
 
 /*


### PR DESCRIPTION
This PR restores ACL support that was removed in commit 084d75ba.
The original behaviour is restored, that is ACL rules can be applied only to IPv4 addresses. IPv6 addresses are not yet supported.
This feature is useful in Gateway mode, when clients from the network can connect to _cntlm_.
Since only IPv4 addresses can be configured, IPv6 listening sockets are configured to accept connections only from IPv6 addresses and not from IPv4-mapped IPv6 addresses.