### PR TITLE
Prefer clang over gcc in configure, and clean makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,11 @@ OS		:= $(shell uname -s)
 OSLDFLAGS	:= $(shell [ $(OS) = "SunOS" ] && echo "-lrt -lsocket -lnsl")
 LDFLAGS		:= -lpthread $(OSLDFLAGS)
 CYGWIN_REQS	:= cygwin1.dll cygrunsrv.exe
-GCC_GTEQ_430 := $(shell expr `${CC} -dumpfullversion | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/'` \>= 40300)
-GCC_GTEQ_450 := $(shell expr `${CC} -dumpfullversion | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/'` \>= 40500)
-GCC_GTEQ_600 := $(shell expr `${CC} -dumpfullversion | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/'` \>= 60000)
-GCC_GTEQ_700 := $(shell expr `${CC} -dumpfullversion | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/'` \>= 70000)
+GCC_VER := $(shell ${CC} -dumpfullversion | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/')
+GCC_GTEQ_430 := $(shell expr ${GCC_VER} \>= 40300)
+GCC_GTEQ_450 := $(shell expr ${GCC_VER} \>= 40500)
+GCC_GTEQ_600 := $(shell expr ${GCC_VER} \>= 60000)
+GCC_GTEQ_700 := $(shell expr ${GCC_VER} \>= 70000)
 
 CFLAGS	+= -std=c99 -D__BSD_VISIBLE -D_ALL_SOURCE -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200112 -D_ISOC99_SOURCE -D_REENTRANT -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_DARWIN_C_SOURCE -DVERSION=\"'$(VER)'\"
 CFLAGS	+= -Wall -Wextra -pedantic -Wshadow -Wcast-qual -Wbad-function-cast -Wstrict-prototypes
@@ -79,12 +80,10 @@ ifeq ($(ENABLE_PACPARSER),1)
 	LDFLAGS+=-lpacparser
 endif
 
-
 ENABLE_STATIC=$(shell grep -c ENABLE_STATIC config/config.h)
 ifeq ($(ENABLE_STATIC),1)
         LDFLAGS+=-static
 endif
-
 
 all: $(NAME)
 

--- a/Makefile.clang
+++ b/Makefile.clang
@@ -20,12 +20,12 @@ OSLDFLAGS	:= $(shell [ $(OS) = "SunOS" ] && echo "-lrt -lsocket -lnsl")
 LDFLAGS		:= -lpthread $(OSLDFLAGS)
 CYGWIN_REQS	:= cygwin1.dll cygrunsrv.exe
 
-CFLAGS	+= -std=c99 -D__BSD_VISIBLE -D_ALL_SOURCE -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200112 -D_ISOC99_SOURCE -D_REENTRANT -D_BSD_SOURCE -D_DARWIN_C_SOURCE -DVERSION=\"'$(VER)'\"
+CFLAGS	+= -std=c99 -D__BSD_VISIBLE -D_ALL_SOURCE -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200112 -D_ISOC99_SOURCE -D_REENTRANT -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_DARWIN_C_SOURCE -DVERSION=\"'$(VER)'\"
 CFLAGS	+= -Wall -Wextra -pedantic -Wshadow -Wcast-qual -Wbad-function-cast -Wstrict-prototypes
-#CFLAGS	+= -v
+CFLAGS	+= -v
 ifeq ($(DEBUG),1)
 	# DEBUG
-	CFLAGS	+= -g -O3
+	CFLAGS	+= -g -O0
 else
 	# RELEASE
 	CFLAGS	+= -O3
@@ -48,12 +48,10 @@ ifeq ($(ENABLE_PACPARSER),1)
 	LDFLAGS+=-lpacparser
 endif
 
-
 ENABLE_STATIC=$(shell grep -c ENABLE_STATIC config/config.h)
 ifeq ($(ENABLE_STATIC),1)
         LDFLAGS+=-static
 endif
-
 
 all: $(NAME)
 
@@ -151,19 +149,19 @@ endif
 	@echo Win64: generating GUI installer
 	@win/Inno5/ISCC.exe /Q win/setup.iss #/Q win/setup.iss
 
-$(NAME)-$(VER)-win64.zip: 
+$(NAME)-$(VER)-win64.zip:
 	@echo Win64: creating ZIP release for manual installs
 	@ln -s win $(NAME)-$(VER)
-	zip -9 $@ $(patsubst %, $(NAME)-$(VER)/%, cntlm.exe $(CYGWIN_REQS) cntlm.ini LICENSE.txt cntlm_manual.pdf) 
+	zip -9 $@ $(patsubst %, $(NAME)-$(VER)/%, cntlm.exe $(CYGWIN_REQS) cntlm.ini LICENSE.txt cntlm_manual.pdf)
 	@rm -f $(NAME)-$(VER)
 
-win/cntlm.ini: doc/cntlm.conf 
+win/cntlm.ini: doc/cntlm.conf
 	@cat doc/cntlm.conf | unix2dos > $@
 
 win/LICENSE.txt: COPYRIGHT LICENSE
 	@cat COPYRIGHT LICENSE | unix2dos > $@
 
-win/cntlm_manual.pdf: doc/cntlm.1 
+win/cntlm_manual.pdf: doc/cntlm.1
 	@echo Win64: generating PDF manual
 	@rm -f $@
 	@groff -t -e -mandoc -Tps doc/cntlm.1 | ps2pdf - $@

--- a/configure
+++ b/configure
@@ -21,7 +21,7 @@ if [ -n "$CC" ]; then
 fi
 
 if [ -z "$CC" ]; then
-	CCS="xlc_r gcc clang"
+	CCS="xlc_r clang gcc"
 
 	#
 	# Look for supported compilers


### PR DESCRIPTION
Commit 59113983 revealed to me that on macOS (monterey) `/usr/bin/gcc` is actually `/usr/bin/clang` and clang doesn't have the option `-dumpfullversion` (there's only `-dumpversion`). Also, many `-W` options are different in clang.
Swapping gcc and clang in `configure` solves the issue by selecting the clang Makefile on macOS. On systems where only gcc is present the behaviour is unchanged.

In the Makefile (gcc) I tried to improve readability by isolating the command to extract the gcc version.