### PR TITLE
Free resources of pacparser and sspi on shutdown

### DIFF
--- a/main.c
+++ b/main.c
@@ -134,14 +134,9 @@ pthread_mutex_t pacparser_mtx = PTHREAD_MUTEX_INITIALIZER;
  * General signal handler. If in debug mode, quit immediately.
  */
 void sighandler(int p) {
-	if (!quit) {
+	if (!quit)
 		syslog(LOG_INFO, "Signal %d received, issuing clean shutdown\n", p);
-#ifdef ENABLE_PACPARSER
-		if (pacparser_initialized) {
-			pacparser_cleanup();
-		}
-#endif
-	} else
+	else
 		syslog(LOG_INFO, "Signal %d received, forcing shutdown\n", p);
 
 	if (quit++ || debug)
@@ -2049,6 +2044,10 @@ bailout:
 	plist_free(rules);
 
 #ifdef ENABLE_PACPARSER
+	if (pacparser_initialized) {
+		pacparser_cleanup();
+	}
+
 	free(pac_file);
 #endif
 

--- a/main.c
+++ b/main.c
@@ -2058,5 +2058,10 @@ bailout:
 
 	proxylist_free(parent_list);
 
+#ifdef __CYGWIN__
+	if (sspi_enabled())
+		sspi_unset();
+#endif
+
 	exit(0);
 }

--- a/sspi.c
+++ b/sspi.c
@@ -50,8 +50,6 @@ void UnloadSecurityDll(HMODULE hModule) {
 	if (hModule)
 		FreeLibrary(hModule);
 
-	sspi_dll = NULL;
-
 	_AcceptSecurityContext      = NULL;
 	_AcquireCredentialsHandle   = NULL;
 	_CompleteAuthToken          = NULL;
@@ -193,6 +191,15 @@ int sspi_set(char* mode)
 	}
 	sspi_mode = NULL;
 	return 0;
+}
+
+int sspi_unset(char* mode)
+{
+	free(sspi_mode);
+	sspi_mode = NULL;
+	UnloadSecurityDll(sspi_dll);
+	sspi_dll = NULL;
+	return 1;
 }
 
 int sspi_request(char **dst, struct sspi_handle *sspi)

--- a/sspi.h
+++ b/sspi.h
@@ -42,6 +42,7 @@ struct sspi_handle
 
 extern int sspi_enabled(void);
 extern int sspi_set(char *mode);
+extern int sspi_unset();
 
 extern int sspi_request(char **dst, struct sspi_handle *sspi);
 extern int sspi_response(char **dst, char *challenge, int challen, struct sspi_handle *sspi);


### PR DESCRIPTION
_Pacparser_ resources are cleaned too early, that is when the first _sigterm_ signal is received. But _cntlm_ can still serve requests, so _pacparser_ is still needed. This PR moves the clean up at the very end of the execution.

Also, _sspi_ resources (Windows only) were not freed, causing another leak. This PR fixes this.