### PR TITLE
Fallback to ntlmv2 when kerberos authentication fails

### DIFF
--- a/main.c
+++ b/main.c
@@ -1577,9 +1577,6 @@ int main(int argc, char **argv) {
 #ifdef ENABLE_KERBEROS
 		} else if (!strcasecmp("gss", cauth)) {
 			g_creds->haskrb = KRB_FORCE_USE_KRB;
-			g_creds->hashnt = 0;
-			g_creds->hashlm = 0;
-			g_creds->hashntlm2 = 0;
 			syslog(LOG_INFO, "Forcing GSS auth.\n");
 #endif
 		} else {


### PR DESCRIPTION
Current Kerberos implementation falls back to NTLMv2 authentication but, since NTLMv2 is disabled when Kerberos is chosen, it always fails even if credentials are provided in the configuration file.
This PR keeps NTLMv2 enabled (as default) when Kerberos is chosen.
I have a scenario when some proxies accept kerberos but one accepts only ntlm.