### PR TITLE
do not attempt authentication to target server when request has a body

### DIFF
--- a/direct.c
+++ b/direct.c
@@ -330,7 +330,8 @@ rr_data_t direct_request(void *cdata, rr_data_const_t request) {
 				goto bailout;
 			}
 
-			if (loop == 1 && data[1]->code == 401 && hlist_subcmp_all(data[1]->headers, "WWW-Authenticate", "NTLM")) {
+			if (loop == 1 && data[1]->code == 401 && hlist_subcmp_all(data[1]->headers, "WWW-Authenticate", "NTLM") &&
+				!http_has_body(data[0], NULL)) {
 				/*
 				 * Server closing the connection after 401?
 				 * Should never happen.


### PR DESCRIPTION
This is a fix for issue #77. Cntlm [advertises](http://cntlm.sourceforge.net/) to be able to authenticate with NTLM against web servers. This works unless the request that needs authentication has a body (e.g. a POST request). In this case the body should be cached so that it could be sent again when the authentication sequence is completed, but Cntlm doesn't cache it, it simply reads data from the client socket and writes it to the server socket.

This use case is probably very rare nowadays, since usually connections use SSL (i.e. https) and Cntlm simply tunnels them.
So adding the logic to deal with plain http connections that require ntlm authentication and have a body in the request (that is, cache the body of the first request) isn't worth the effort.

Instead of removing the feature completely it is very easy to add a check that the incoming request does not have a body (typically a GET) and avoid the authentication attempt in case the body is not empty.