### PR TITLE
direct: do not try to read 401 body after a Connection: close

### DIFF
--- a/direct.c
+++ b/direct.c
@@ -357,6 +357,11 @@ rr_data_t direct_request(void *cdata, rr_data_const_t request) {
 					if (debug)
 						printf("Reconnect before WWW auth\n");
 					close(sd);
+					/*
+					 * Make sure nobody tries to read the body, particularly http_body_drop():
+					 * now that we closed the socket, it would wait indefinitely.
+					 */
+					data[1]->headers = hlist_mod(data[1]->headers, "Content-Length", "0", 1);
 					sd = host_connect(data[0]->hostname, data[0]->port);
 					if (sd < 0) {
 						tmp = gen_502_page(data[0]->http, "WWW authentication reconnect failed");


### PR DESCRIPTION
fixes #85.

- added constant BODY_VANISHED with this special meaning of "was not empty, but is now"
- http_body_drop() gets aware of BODY_VANISHED
- direct_request(): set BODY_VANISHED when closing and reopening

Not totally sure if this is the cleanest way to resolve it (maybe having a negative const for a length is a worst practice, maybe the BODY_VANISHED could have been detected more generally in `http_has_body()` than in the specialized `http_body_drop()`.