### PR TITLE
manage large Kerberos tokens

### DIFF
--- a/Makefile.clang
+++ b/Makefile.clang
@@ -41,7 +41,11 @@ endif
 ENABLE_KERBEROS=$(shell grep -c ENABLE_KERBEROS config/config.h)
 ifeq ($(ENABLE_KERBEROS),1)
 	OBJS+=kerberos.o
+ifeq ($(OS),Darwin)
+	LDFLAGS+=-framework GSS
+else
 	LDFLAGS+=-lgssapi_krb5
+endif
 endif
 
 ENABLE_STATIC=$(shell grep -c ENABLE_STATIC config/config.h)

--- a/kerberos.c
+++ b/kerberos.c
@@ -249,7 +249,7 @@ int client_establish_context(char *service_name,
  * acquires a kerberos token for default credential using SPN HTTP@<thost>
  */
 int acquire_kerberos_token(const char* hostname, struct auth_s *credentials,
-		char* buf, size_t bufsize) {
+		char** buf, size_t *bufsize) {
 	char service_name[BUFSIZE];
 	OM_uint32 ret_flags, min_stat;
 
@@ -277,20 +277,29 @@ int acquire_kerberos_token(const char* hostname, struct auth_s *credentials,
 	int rc = client_establish_context(service_name, &ret_flags, &send_tok);
 
 	if (rc == GSS_S_COMPLETE) {
-		char token[BUFSIZE];
+		char *token = NULL;
+		size_t token_size;
 		credentials->haskrb = KRB_OK;
 
-		to_base64((unsigned char *) token, send_tok.value, send_tok.length,
-				BUFSIZE);
-
-		if (debug) {
-			printf("Token B64 (size=%d)... %s\n",
-					(int) strlen(token), token);
-			display_ctx_flags(ret_flags);
+		// approximately compute size of token in base64
+		token_size = 4*send_tok.length;
+		token_size /= 3;
+		token_size += 4 + 4;
+		if (token_size + 10 + 1 > *bufsize) {
+			// *bufsize must be >= token_size + length of "NEGOTIATE " (10) + null terminator (1)
+			*bufsize = token_size + 10 + 1;
+			*buf = realloc(*buf, *bufsize);
 		}
 
-		strlcpy(buf, "NEGOTIATE ", bufsize);
-		strlcat(buf, token, bufsize);
+		strlcpy(*buf, "NEGOTIATE ", *bufsize);
+		token = *buf + 10;
+
+		to_base64((unsigned char *)token, send_tok.value, send_tok.length, token_size);
+
+		if (debug) {
+			printf("Token B64 (%d size=%d)... %s\n", (int)token_size, (int)strlen(token), token);
+			display_ctx_flags(ret_flags);
+		}
 
 		rc=1;
 	} else {

--- a/kerberos.c
+++ b/kerberos.c
@@ -46,7 +46,11 @@
 
 #include <string.h>
 #include <stdio.h>
+#ifdef __APPLE__
+#include <GSS/GSS.h>
+#else
 #include <gssapi/gssapi.h>
+#endif
 #include <stdlib.h>
 
 /*
@@ -130,12 +134,10 @@ void display_status(char *msg, OM_uint32 maj_stat, OM_uint32 min_stat) {
 }
 
 void display_name(char* txt, gss_name_t *name) {
-	gss_OID mechOid = GSS_C_NO_OID;
 	OM_uint32 maj_stat;
 	OM_uint32 min_stat;
 	gss_buffer_desc out_name;
 
-//	maj_stat = gss_display_name(&min_stat, *name, &out_name, &mechOid);
 	maj_stat = gss_display_name(&min_stat, *name, &out_name, NULL);
 	if (maj_stat != GSS_S_COMPLETE && debug) {
 		display_status("Display name", maj_stat, min_stat);
@@ -144,9 +146,6 @@ void display_name(char* txt, gss_name_t *name) {
 	printf("%s %s\n", txt, (char *)out_name.value);
 
 	(void) gss_release_buffer(&min_stat, &out_name);
-
-	if (mechOid != GSS_C_NO_OID)
-		(void) gss_release_oid(&min_stat, &mechOid);
 }
 
 int acquire_name(gss_name_t *target_name, char *service_name, gss_OID oid) {
@@ -311,7 +310,7 @@ int acquire_kerberos_token(const char* hostname, struct auth_s *credentials,
 /**
  * checks if a default cached credential is cached
  */
-int check_credential() {
+int check_credential(void) {
 	OM_uint32 min_stat;
 	gss_name_t name;
 	OM_uint32 lifetime;

--- a/kerberos.h
+++ b/kerberos.h
@@ -43,7 +43,7 @@
 /**
  * acquires a kerberos token for default credential using SPN HTTP@<thost>
  */
-int acquire_kerberos_token(const char* hostname, struct auth_s *credentials, char* buf, size_t bufsize);
+int acquire_kerberos_token(const char* hostname, struct auth_s *credentials, char** buf, size_t *bufsize);
 
 /**
  * checks if a default cached credential is cached


### PR DESCRIPTION
This patch checks whether the returned Kerberos token, encoded in base64, fits the available buffer. If it is larger, the buffer is reallocated with the required dimension.
This patch was circulating for a few years and was recently proposed here by @bas524. I just cleaned it up a bit and made the reallocation conditional only when it is necessary to expand the buffer.

In the meantime, for the macos version, I replaced the deprecated `gssapi` apis with the `GSS framework` and removed some deprecated code.   