### PR TITLE
Resolve problems connectings coming in via SOCKS

### DIFF
--- a/main.c
+++ b/main.c
@@ -611,22 +611,19 @@ void *socks5_thread(void *thread_data) {
 		i = (sd >= 0);
 	} else {
 		snprintf(tport, MINIBUF_SIZE, "%d", ntohs(port));
+		char *hostname = strdup(thost);
 		strlcat(thost, ":", HOST_BUFSIZE);
 		strlcat(thost, tport, HOST_BUFSIZE);
 
 		tcreds = new_auth();
-		sd = proxy_connect(tcreds, "/", thost);
+		sd = proxy_connect(tcreds, thost, hostname);
 		if (sd == -2) {
-			// remove previously added port to thost
-			char* t = thost;
-			while (*t != ':') ++t;
-			*t = 0;
-
-			sd = host_connect(thost, ntohs(port));
+			sd = host_connect(hostname, ntohs(port));
 			i = (sd >= 0);
 		} else if (sd >= 0) {
 			i = prepare_http_connect(sd, tcreds, thost);
 		}
+		free(hostname);
 	}
 
 	/*


### PR DESCRIPTION
I was running into issues with connections that were reaching CNTLM via SOCKS. First of all it would try to use a proxy server whereas according to the PAC file there would be a direct connection. It seems that specifying `/` as the URL was not what the rest of the code was expecting. I saw that other code was passing the hostname or IP address instead plus the port number and the hostname or IP address without a port number. Once I changed that,, connections were made correctly directly.

I also saw problems due to the incomplete `data1` structure after the code was passing through `prepare_http_connect`, so I added the hostname and port number to it. This can result in a segfault later on as the data is expected to be there.

With these fixes in place CNTLM is not crashing anymore and handling SOCKS connections without problems. I guess the code is not perfect though, so I'd be happy to get any feedback that would help to improve things :)