### PR TITLE
Support for up to 256c passphrases, correct bitwise inversion in hashes

### DIFF
--- a/http.c
+++ b/http.c
@@ -661,15 +661,15 @@ int http_parse_basic(hlist_const_t headers, const char *header, struct auth_s *t
 
 	tmp = hlist_get(headers, header);
 	assert(tmp != NULL);
-	buf = zmalloc(strlen(tmp) + 1);
+	size_t header_bufsize = strlen(tmp) + 1;
+	buf = zmalloc(header_bufsize);
 	i = 5;
 	while (i < strlen(tmp) && tmp[++i] == ' ');
 	from_base64(buf, tmp+i);
 	pos = strchr(buf, ':');
 
 	if (pos == NULL) {
-		memset(buf, 0, strlen(buf));
-		__asm__ volatile ("" ::: "memory"); /* clean password memory; try to avoid the compiler optimizing this out */
+		compat_memset_s(buf, header_bufsize, 0, strlen(buf)); /* clean memory containing credentials */
 		free(buf);
 		return -1;
 	} else {
@@ -702,8 +702,7 @@ int http_parse_basic(hlist_const_t headers, const char *header, struct auth_s *t
 			free(tmp);
 		}
 
-		memset(buf, 0, strlen(buf));
-		__asm__ volatile ("" ::: "memory");
+		compat_memset_s(buf, header_bufsize, 0, strlen(buf));
 		free(buf);
 	}
 

--- a/http.c
+++ b/http.c
@@ -668,7 +668,8 @@ int http_parse_basic(hlist_const_t headers, const char *header, struct auth_s *t
 	pos = strchr(buf, ':');
 
 	if (pos == NULL) {
-		memset(buf, 0, strlen(buf));	/* clean password memory */ /* FIXME: This is very likely to be optimized away and password remains in memory. */
+		memset(buf, 0, strlen(buf));
+		__asm__ volatile ("" ::: "memory"); /* clean password memory; try to avoid the compiler optimizing this out */
 		free(buf);
 		return -1;
 	} else {
@@ -702,6 +703,7 @@ int http_parse_basic(hlist_const_t headers, const char *header, struct auth_s *t
 		}
 
 		memset(buf, 0, strlen(buf));
+		__asm__ volatile ("" ::: "memory");
 		free(buf);
 	}
 

--- a/main.c
+++ b/main.c
@@ -739,7 +739,7 @@ int main(int argc, char **argv) {
 	g_creds = new_auth();
 	cuser = zmalloc(MINIBUF_SIZE);
 	cdomain = zmalloc(MINIBUF_SIZE);
-	cpassword = zmalloc(MINIBUF_SIZE);
+	cpassword = zmalloc(PASSWORD_BUFSIZE);
 	cpassntlm2 = zmalloc(MINIBUF_SIZE);
 	cpassnt = zmalloc(MINIBUF_SIZE);
 	cpasslm = zmalloc(MINIBUF_SIZE);
@@ -845,7 +845,7 @@ int main(int argc, char **argv) {
 				 * Overwrite the password parameter with '*'s to make it
 				 * invisible in "ps", /proc, etc.
 				 */
-				strlcpy(cpassword, optarg, MINIBUF_SIZE);
+				strlcpy(cpassword, optarg, PASSWORD_BUFSIZE);
 				for (i = strlen(optarg)-1; i >= 0; --i)
 					optarg[i] = '*';
 				break;
@@ -1216,7 +1216,7 @@ int main(int argc, char **argv) {
 		 */
 		CFG_DEFAULT(cf, "Auth", cauth, MINIBUF_SIZE)
 		CFG_DEFAULT(cf, "Domain", cdomain, MINIBUF_SIZE)
-		CFG_DEFAULT(cf, "Password", cpassword, MINIBUF_SIZE)
+		CFG_DEFAULT(cf, "Password", cpassword, PASSWORD_BUFSIZE)
 		CFG_DEFAULT(cf, "PassNTLMv2", cpassntlm2, MINIBUF_SIZE)
 		CFG_DEFAULT(cf, "PassNT", cpassnt, MINIBUF_SIZE)
 		CFG_DEFAULT(cf, "PassLM", cpasslm, MINIBUF_SIZE)
@@ -1396,7 +1396,7 @@ int main(int argc, char **argv) {
 		termnew = termold;
 		termnew.c_lflag &= ~(ISIG | ECHO);
 		tcsetattr(0, TCSADRAIN, &termnew);
-		tmp = fgets(cpassword, MINIBUF_SIZE, stdin);
+		tmp = fgets(cpassword, PASSWORD_BUFSIZE, stdin);
 		tcsetattr(0, TCSADRAIN, &termold);
 		i = strlen(cpassword) - 1;
 		if (cpassword[i] == '\n') {
@@ -1457,6 +1457,7 @@ int main(int argc, char **argv) {
 			free(tmp);
 		}
 		memset(cpassword, 0, strlen(cpassword));
+		__asm__ volatile ("" ::: "memory");
 	}
 
 	auth_strcpy(g_creds, user, cuser);

--- a/main.c
+++ b/main.c
@@ -1456,8 +1456,7 @@ int main(int argc, char **argv) {
 			auth_memcpy(g_creds, passntlm2, tmp, 16);
 			free(tmp);
 		}
-		memset(cpassword, 0, strlen(cpassword));
-		__asm__ volatile ("" ::: "memory");
+		compat_memset_s(cpassword, PASSWORD_BUFSIZE, 0, strlen(cpassword));
 	}
 
 	auth_strcpy(g_creds, user, cuser);

--- a/utils.c
+++ b/utils.c
@@ -821,7 +821,7 @@ int unicode(char **dst, const char * const src) {
 		return 0;
 	}
 
-	l = MIN(64, strlen(src));
+	l = MIN(BUFSIZE, strlen(src));
 	tmp = zmalloc(2*l);
 	for (i = 0; i < l; ++i)
 		tmp[2*i] = src[i];
@@ -855,12 +855,14 @@ char *urlencode(const char * const str) {
 
 char *printmem(const char * const src, const size_t len, const int bitwidth) {
 	char *tmp;
+	uint8_t val;
 	size_t i;
 
 	tmp = zmalloc(2*len+1);
 	for (i = 0; i < len; ++i) {
-		tmp[i*2] = hextab[((uint8_t)src[i] ^ (uint8_t)(7-bitwidth)) >> 4];
-		tmp[i*2+1] = hextab[(src[i] ^ (uint8_t)(7-bitwidth)) & 0x0F];
+		val = (uint8_t)src[i] & (0xFF >> (8-bitwidth));
+		tmp[i*2] = hextab[val >> 4];
+		tmp[i*2+1] = hextab[val & 0x0F];
 	}
 
 	return tmp;
@@ -884,7 +886,7 @@ char *scanmem(const char * const src, const int bitwidth) {
 			free(tmp);
 			return NULL;
 		}
-		tmp[i] = ((h << 4) + l) ^ (uint8_t)(7-bitwidth);
+		tmp[i] = ((h << 4) + l) & (0xFF >> (8-bitwidth));
 	}
 	tmp[i] = 0;
 

--- a/utils.c
+++ b/utils.c
@@ -855,12 +855,11 @@ char *urlencode(const char * const str) {
 
 char *printmem(const char * const src, const size_t len, const int bitwidth) {
 	char *tmp;
-	uint8_t val;
 	size_t i;
 
 	tmp = zmalloc(2*len+1);
 	for (i = 0; i < len; ++i) {
-		val = (uint8_t)src[i] & (0xFF >> (8-bitwidth));
+		uint8_t val = (uint8_t)src[i] & (0xFF >> (8-bitwidth));
 		tmp[i*2] = hextab[val >> 4];
 		tmp[i*2+1] = hextab[val & 0x0F];
 	}
@@ -1127,4 +1126,12 @@ ssize_t write_wrapper(int fildes, const void *buf, const size_t nbyte)
 	}
 
 	return retval;
+}
+
+void compat_memset_s( void *dest, size_t destsz, char ch, size_t count ){
+	count = MIN(count, destsz);
+	volatile unsigned char *p = dest;
+	while (count--){
+		*p++ = ch;
+	}
 }

--- a/utils.h
+++ b/utils.h
@@ -200,6 +200,8 @@ extern uint64_t getrandom64(void) __attribute__((warn_unused_result));
 
 extern ssize_t write_wrapper(int fildes, const void *buf, const size_t nbyte);
 
+extern void compat_memset_s( void *dest, size_t destsz, char ch, size_t count );
+
 #if config_strdup == 0
 extern char *strdup(const char *src)  __attribute__((warn_unused_result));
 #endif

--- a/utils.h
+++ b/utils.h
@@ -32,6 +32,12 @@
 
 #define BUFSIZE			4096
 #define MINIBUF_SIZE		50
+/*
+* Longest password that appears to be supported in a Microsoft authn/authz implementation is 256 characters;
+* therefore support passwords up to 256 characters plus null terminator.
+* source: https://learn.microsoft.com/en-us/entra/identity/authentication/concept-password-ban-bad-combined-policy#azure-ad-password-policies
+*/
+#define PASSWORD_BUFSIZE	257
 #define HOST_BUFSIZE	260
 #define VAL(var, type, offset)	*((type *)(var+offset))
 #define MEM(var, type, offset)	(type *)(var+offset)


### PR DESCRIPTION
This PR updates the password buffer size to support up to 256 character passwords (the maximum supported by Microsoft in any known NTLM implementation) as well as addresses the following 2 issues:

- Hashes as generated and consumed have all bits complemented (making such disagree with all other NTHash implementations such as passlib). Therefore, this PR corrects this behavior however **will require users using a pre-hashed password in config to recompute the hash**.

- Passwords remain in memory (per the referenced FIXME) even when no longer necessary; this change adds an explicit memory barrier after the memset to zero on the password buffer in an event to prevent the compiler from optimizing away the memset.