### PR TITLE
automatically check availability of gss at build time

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -35,12 +35,6 @@ jobs:
         CFLAGS=-DUNICODE make
         ./cntlm -h
         make distclean
-    - name: Build with kerberos enabled
-      run: |
-        ./configure --enable-kerberos
-        make
-        ./cntlm -h
-        make distclean
     - name: Verify debug build
       run: |
         ./configure

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -23,11 +23,6 @@ jobs:
         ./configure
         CFLAGS=-DUNICODE make
         make clean
-    - name: Build with kerberos enabled
-      run: |
-        ./configure --enable-kerberos
-        make
-        make clean
     - name: Verify debug build
       run: |
         ./configure

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ cntlm*.tar.gz
 /config/arc4random_buf
 /config/strlcat
 /config/strlcpy
+/config/gss
 /config/*.exe
 /win/*.exe
 /win/*.dll

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,8 @@ endif
 
 OBJS=main.o utils.o ntlm.o xcrypt.o config.o socket.o acl.o auth.o http.o forward.o direct.o scanner.o pages.o proxy.o pac.o duktape.o
 
-ENABLE_KERBEROS=$(shell grep -c ENABLE_KERBEROS config/config.h)
-ifeq ($(ENABLE_KERBEROS),1)
+CONFIG_GSS=$(shell grep -c "config_gss 1" config/config.h)
+ifeq ($(CONFIG_GSS),1)
 	OBJS+=kerberos.o
 ifeq ($(OS),Darwin)
 	LDFLAGS+=-framework GSS
@@ -230,7 +230,7 @@ uninstall:
 	rm -f $(BINDIR)/$(NAME) $(MANDIR)/man1/$(NAME).1 2>/dev/null || true
 
 clean:
-	@rm -f config/endian config/gethostname config/strdup config/socklen_t config/arc4random_buf config/strlcat config/strlcpy config/*.exe
+	@rm -f config/endian config/gethostname config/strdup config/socklen_t config/arc4random_buf config/strlcat config/strlcpy config/gss config/*.exe
 	@rm -f *.o cntlm cntlm.exe configure-stamp build-stamp config/config.h
 	@rm -f $(patsubst %, win/%, $(CYGWIN_REQS) cntlm.exe cntlm.ini LICENSE.txt resources.o setup.iss cntlm_manual.pdf)
 

--- a/auth.c
+++ b/auth.c
@@ -46,7 +46,7 @@ struct auth_s *new_auth(void) {
 	tmp->hashnt = 0;
 	tmp->hashlm = 0;
 	tmp->flags = 0;
-#ifdef ENABLE_KERBEROS
+#if config_gss == 1
 	tmp->haskrb = 0;
 #endif
 
@@ -58,7 +58,7 @@ struct auth_s *copy_auth(struct auth_s *dst, const struct auth_s *src, int fullc
 	dst->hashnt = src->hashnt;
 	dst->hashlm = src->hashlm;
 	dst->flags = src->flags;
-#ifdef ENABLE_KERBEROS
+#if config_gss == 1
 	dst->haskrb = src->haskrb;
 #endif
 

--- a/auth.h
+++ b/auth.h
@@ -47,7 +47,7 @@ struct auth_s {
 #ifdef __CYGWIN__
 	struct sspi_handle sspi;
 #endif
-#ifdef ENABLE_KERBEROS
+#if config_gss == 1
 	int haskrb;
 #endif
 	uint32_t flags;

--- a/config/gss.c
+++ b/config/gss.c
@@ -1,0 +1,28 @@
+#include <dlfcn.h>
+#ifdef __APPLE__
+#include <GSS/GSS.h>
+#else
+#include <gssapi/gssapi.h>
+#endif
+
+OM_uint32 (*_gss_display_status)(OM_uint32 *, OM_uint32, int, gss_OID, OM_uint32 *, gss_buffer_t) = NULL;
+
+int main(int argc, char **argv) {
+	int retval = 0;
+	void *handle;
+
+	char* library =
+#ifdef __APPLE__
+		"/System/Library/Frameworks/GSS.framework/GSS";
+#else
+		"libgssapi_krb5.so";
+#endif
+	handle = dlopen(library, RTLD_LAZY);
+	if (handle) {
+		_gss_display_status = dlsym(handle, "gss_display_status");
+		retval = _gss_display_status != NULL;
+		dlclose(handle);
+	}
+
+	return !!retval;
+}

--- a/configure
+++ b/configure
@@ -45,7 +45,7 @@ else
 fi
 
 CONFIG=config/config.h
-TESTS="endian strdup socklen_t gethostname arc4random_buf strlcat strlcpy"
+TESTS="endian strdup socklen_t gethostname arc4random_buf strlcat strlcpy gss"
 
 rm -f $CONFIG
 echo "#ifndef CONFIGURE_CONFIG_H" > $CONFIG
@@ -73,10 +73,6 @@ done
 while [ "$1" ]
 do
 	case $1 in
-		--enable-kerberos)
-			printf "#define ENABLE_KERBEROS" >> $CONFIG
-			echo "" >> $CONFIG
-			;;
 		--enable-static)
 			printf "#define ENABLE_STATIC" >> $CONFIG
 			echo "" >> $CONFIG

--- a/main.c
+++ b/main.c
@@ -70,7 +70,7 @@
 #include "sspi.h"				/* code for SSPI management */
 #endif
 
-#ifdef ENABLE_KERBEROS
+#if config_gss == 1
 #include "kerberos.h"
 #endif
 
@@ -957,7 +957,7 @@ int main(int argc, char **argv) {
 		fprintf(stream, "\t-A  <address>[/<net>]\n"
 				"\t    ACL allow rule. IP or hostname, net must be a number (CIDR notation)\n");
 		fprintf(stream, "\t-a  ntlm | nt | lm"
-#ifdef ENABLE_KERBEROS
+#if config_gss == 1
 				" | gss\n"
 				"\t    Authentication type - combined NTLM, just LM, just NT, or GSS. Default NTLM.\n"
 				"\t    GSS activates kerberos auth: you need a cached credential.\n"
@@ -1364,7 +1364,7 @@ int main(int argc, char **argv) {
 			g_creds->hashnt = 2;
 			g_creds->hashlm = 0;
 			g_creds->hashntlm2 = 0;
-#ifdef ENABLE_KERBEROS
+#if config_gss == 1
 		} else if (!strcasecmp("gss", cauth)) {
 			g_creds->haskrb = KRB_FORCE_USE_KRB;
 			syslog(LOG_INFO, "Forcing GSS auth.\n");
@@ -1507,7 +1507,7 @@ int main(int argc, char **argv) {
 	 * If we're going to need a password, check we really have it.
 	 */
 	if (!ntlmbasic &&
-#ifdef ENABLE_KERBEROS
+#if config_gss == 1
 			!g_creds->haskrb &&
 #endif
 #ifdef __CYGWIN__
@@ -1571,7 +1571,7 @@ int main(int argc, char **argv) {
 		setlogmask(LOG_UPTO(LOG_INFO));
 	}
 
-#ifdef ENABLE_KERBEROS
+#if config_gss == 1
 	if (g_creds->haskrb & KRB_FORCE_USE_KRB) {
 		g_creds->haskrb |= check_credential();
 		if(g_creds->haskrb & KRB_CREDENTIAL_AVAILABLE)

--- a/proxy.c
+++ b/proxy.c
@@ -32,7 +32,7 @@
 #include "ntlm.h"
 #include "proxy.h"
 
-#ifdef ENABLE_KERBEROS
+#if config_gss == 1
 #include "kerberos.h"
 #endif
 
@@ -89,7 +89,7 @@ proxylist_t parent_list = NULL;
 unsigned long parent_curr = 0;
 pthread_mutex_t parent_mtx = PTHREAD_MUTEX_INITIALIZER;
 
-#ifdef ENABLE_KERBEROS
+#if config_gss == 1
 proxy_t *curr_proxy;
 #endif
 
@@ -479,7 +479,7 @@ int proxy_connect(struct auth_s *credentials, const char* url, const char* hostn
 				proxy = p->proxy;
 				syslog(LOG_ERR, "Proxy connect failed, will try %s:%d\n", proxy->hostname, proxy->port);
 			}
-#ifdef ENABLE_KERBEROS
+#if config_gss == 1
 		} else {
 			//kerberos needs the hostname of the parent proxy for generate the token, so we keep it
 			curr_proxy = proxy;
@@ -543,7 +543,7 @@ int proxy_authenticate(int *sd, rr_data_t request, rr_data_t response, struct au
 	size_t bufsize = BUFSIZE;
 	buf = zmalloc(bufsize);
 
-#ifdef ENABLE_KERBEROS
+#if config_gss == 1
 	if(g_creds->haskrb && acquire_kerberos_token(curr_proxy->hostname, credentials, &buf, &bufsize)) {
 		//pre auth, we try to authenticate directly with kerberos, without to ask if auth is needed
 		//we assume that if kdc releases a ticket for the proxy, then the proxy is configured for kerberos auth
@@ -561,7 +561,7 @@ int proxy_authenticate(int *sd, rr_data_t request, rr_data_t response, struct au
 			free(tmp);
 		}
 
-#ifdef ENABLE_KERBEROS
+#if config_gss == 1
 	}
 #endif
 
@@ -648,7 +648,7 @@ int proxy_authenticate(int *sd, rr_data_t request, rr_data_t response, struct au
 		tmp = hlist_get(auth->headers, "Proxy-Authenticate");
 
 		if (tmp) {
-#ifdef ENABLE_KERBEROS
+#if config_gss == 1
 			if(g_creds->haskrb && strncasecmp(tmp, "NEGOTIATE", 9) == 0 && acquire_kerberos_token(curr_proxy->hostname, credentials, &buf, &bufsize)) {
 				if (debug)
 					printf("Using Negotiation ...\n");
@@ -683,7 +683,7 @@ int proxy_authenticate(int *sd, rr_data_t request, rr_data_t response, struct au
 				}
 
 				free(challenge);
-#ifdef ENABLE_KERBEROS
+#if config_gss == 1
 			}
 #endif
 		} else {


### PR DESCRIPTION
This PR is for removing the optional parameter "--enable-kerberos" when launching "./configure". Now it can automatically check the existence of GSS header files and shared libraries and activate the compiler directive accordingly.
This also simplifies the CI workflows.