### PR TITLE
use memset_s from standard library if available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ cntlm*.tar.gz
 /config/arc4random_buf
 /config/strlcat
 /config/strlcpy
+/config/memset_s
 /config/gss
 /config/*.exe
 /win/*.exe

--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ uninstall:
 	rm -f $(BINDIR)/$(NAME) $(MANDIR)/man1/$(NAME).1 2>/dev/null || true
 
 clean:
-	@rm -f config/endian config/gethostname config/strdup config/socklen_t config/arc4random_buf config/strlcat config/strlcpy config/gss config/*.exe
+	@rm -f config/endian config/gethostname config/socklen_t config/strdup config/arc4random_buf config/strlcat config/strlcpy config/memset_s config/gss config/*.exe
 	@rm -f *.o cntlm cntlm.exe configure-stamp build-stamp config/config.h
 	@rm -f $(patsubst %, win/%, $(CYGWIN_REQS) cntlm.exe cntlm.ini LICENSE.txt resources.o setup.iss cntlm_manual.pdf)
 

--- a/config/memset_s.c
+++ b/config/memset_s.c
@@ -1,0 +1,13 @@
+#define __STDC_WANT_LIB_EXT1__ 1
+#include <string.h>
+
+#define BUFFER_SIZE 16
+
+int main(int argc, char **argv) {
+	int retval;
+	char buffer[BUFFER_SIZE] = {0};
+
+	retval = memset_s(buffer, BUFFER_SIZE, 'a', BUFFER_SIZE);
+
+	return !retval;
+}

--- a/configure
+++ b/configure
@@ -45,7 +45,7 @@ else
 fi
 
 CONFIG=config/config.h
-TESTS="endian strdup socklen_t gethostname arc4random_buf strlcat strlcpy gss"
+TESTS="endian gethostname socklen_t strdup arc4random_buf strlcat strlcpy memset_s gss"
 
 rm -f $CONFIG
 echo "#ifndef CONFIGURE_CONFIG_H" > $CONFIG

--- a/http.c
+++ b/http.c
@@ -702,7 +702,7 @@ int http_parse_basic(hlist_const_t headers, const char *header, struct auth_s *t
 			free(tmp);
 		}
 
-		compat_memset_s(buf, header_bufsize, 0, strlen(buf));
+		compat_memset_s(buf, header_bufsize, 0, header_bufsize);
 		free(buf);
 	}
 

--- a/ntlm.c
+++ b/ntlm.c
@@ -175,7 +175,7 @@ char *ntlm_hash_lm_password(const char *password) {
 	gl_des_ecb_encrypt(&context, magic, keys+8);
 
 	memset(keys+16, 0, 5);
-	memset(pass, 0, 14);
+	compat_memset_s(pass, 15, 0, 14);
 	free(pass);
 
 	return keys;
@@ -191,7 +191,7 @@ char *ntlm_hash_nt_password(const char *password) {
 	md4_buffer(u16, len, keys);
 
 	memset(keys+16, 0, 5);
-	memset(u16, 0, len);
+	compat_memset_s(u16, len, 0, len);
 	free(u16);
 
 	return keys;

--- a/utils.c
+++ b/utils.c
@@ -672,7 +672,7 @@ void free_rr_data(rr_data_t * pdata) {
 	if (data->http) free(data->http);
 	if (data->msg) free(data->msg);
 	if (data->body) free(data->body);
-	memset(data, 0, sizeof(struct rr_data_s));
+
 	free(data);
 	data = NULL;
 }


### PR DESCRIPTION
Following the design of cntlm, checked the availability of memset_s in `configure`.
Also correctly clear password buffers as explained in issue #105 