### PR TITLE
Reorganise some workflows

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -9,12 +9,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        compiler: [gcc, clang]
-    env:
-      CC: ${{ matrix.compiler }}
     steps:
     - uses: actions/checkout@v4
     - name: Install stuff for creating packages
@@ -23,9 +17,15 @@ jobs:
       run: sudo apt install -y libkrb5-dev
     - name: Install further tools (clang-tools for scan-build)
       run: sudo apt install -y clang-tools
-    - name: Normal build
+    - name: Normal build (gcc)
       run: |
-        ./configure
+        CC=gcc ./configure
+        make
+        ./cntlm -h
+        make distclean
+    - name: Normal build (clang)
+      run: |
+        CC=clang ./configure
         make
         ./cntlm -h
         make distclean
@@ -44,7 +44,8 @@ jobs:
         sudo make install
         sudo make uninstall
         make distclean
-    - name: Build via scan-build
+    - name: Build via scan-build (exclude duktape)
       run: |
         ./configure
+        make duktape.o
         scan-build --force-analyze-debug-code make

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -29,12 +29,6 @@ jobs:
         make
         ./cntlm -h
         make distclean
-    - name: Unicode build
-      run: |
-        ./configure
-        CFLAGS=-DUNICODE make
-        ./cntlm -h
-        make distclean
     - name: Verify debug build
       run: |
         ./configure

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -12,6 +12,7 @@ jobs:
   coverity:
     runs-on: ubuntu-latest
     steps:
+    - run: sudo apt install -y libkrb5-dev
     - uses: actions/checkout@v4
     - run: ./configure
     - uses: vapier/coverity-scan-action@v1

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -17,6 +17,6 @@ jobs:
     - uses: vapier/coverity-scan-action@v1
       with:
         command: make
-        project: versat%2Fcntlm
+        project: ${{ github.repository }}
         email: ${{ secrets.COVERITY_SCAN_EMAIL }}
         token: ${{ secrets.COVERITY_SCAN_TOKEN }}

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -18,11 +18,6 @@ jobs:
         ./configure
         make
         make clean
-    - name: Unicode build
-      run: |
-        ./configure
-        CFLAGS=-DUNICODE make
-        make clean
     - name: Verify debug build
       run: |
         ./configure

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -37,6 +37,8 @@ jobs:
           curl -sSLo $HOME/.sonar/build-wrapper-linux-x86.zip ${{ env.BUILD_WRAPPER_DOWNLOAD_URL }}
           unzip -o $HOME/.sonar/build-wrapper-linux-x86.zip -d $HOME/.sonar/
           echo "$HOME/.sonar/build-wrapper-linux-x86" >> $GITHUB_PATH
+      - name: Install packages required for optional configurations of cntlm
+        run: sudo apt install -y libkrb5-dev
       - name: Run build-wrapper
         run: |
           ./configure

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,9 @@ build_script:
 - cmd: >-
     C:\cygwin64\setup-x86_64.exe -qgnO -l C:\cygwin64\var\cache\setup -R c:\cygwin64 -s http://cygwin.mirror.constant.com -P ghostscript -P dos2unix -P zip
 
-    C:\cygwin64\bin\bash -e -l -c "cd /cygdrive/c/projects/cntlm && make distclean && ./configure && make DEBUG=1 && make win"
+    C:\cygwin64\bin\bash -e -l -c "cd /cygdrive/c/projects/cntlm && make distclean && ./configure && make DEBUG=1"
+
+    C:\cygwin64\bin\bash -e -l -c "cd /cygdrive/c/projects/cntlm && make distclean && ./configure && CFLAGS=-DUNICODE make"
 
     C:\cygwin64\bin\bash -e -l -c "cd /cygdrive/c/projects/cntlm && make distclean && ./configure && make && make win"
 


### PR DESCRIPTION
For `c-cpp.yml` it is faster to have one job that compiles first with gcc and then with clang. In scan-build we can exclude duktape because it is third party.
`UNICODE` is relevant only for Cygwin because it is used only in sspi.c.
Finally, we can analyse also kerberos code by installing the developer package during setup.