### PR TITLE
Fetch PAC files from http url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifeq ($(OS),Darwin)
 	ifndef ARCH
 		ARCH := $(shell uname -m)
 	endif
-	CFLAGS := -arch $(ARCH)
+	CFLAGS += -arch $(ARCH)
 # Change binary directory for macOS
 	BINDIR := $(DESTDIR)$(PREFIX)/bin
 endif
@@ -303,4 +303,4 @@ ifeq ($(OS),Linux)
 endif
 	@rm -f *.exe *.deb *.rpm *.tgz *.tar.gz *.tar.bz2 *.zip *.exe *.pkg tags ctags pid 2>/dev/null
 
-.PHONY: all install tgz tbz2 deb rpm win uninstall clean distclean
+.PHONY: all install tgz tbz2 deb rpm mac win uninstall clean distclean

--- a/config.c
+++ b/config.c
@@ -32,9 +32,9 @@ config_t config_open(const char *fname) {
 	FILE *fp;
 	char *buf;
 	char section[MINIBUF_SIZE] = "global";
-	int i;
-	int j;
-	int slen;
+	size_t i;
+	size_t j;
+	size_t slen;
 
 	fp = fopen(fname, "r");
 	if (!fp)
@@ -50,14 +50,14 @@ config_t config_open(const char *fname) {
 		if (!tmp)
 			break;
 
-		const int len = MIN(BUFSIZE, strlen(buf));
+		const size_t len = MIN(BUFSIZE, strlen(buf));
 		if (!len || feof(fp))
 			continue;
 
 		/*
 		 * Find first non-empty character
 		 */
-		for (j = 0; j < len && isspace((u_char)buf[j]); ++j) {};
+		for (j = 0; j < len && isspace((u_char)buf[j]); ++j);
 
 		/*
 		 * Comment?
@@ -68,7 +68,7 @@ config_t config_open(const char *fname) {
 		/*
 		 * Find end of keyword
 		 */
-		for (i = j; j < len && isalnum((u_char)buf[j]); ++j) {};
+		for (i = j; j < len && isalnum((u_char)buf[j]); ++j);
 
 		/*
 		 * Malformed?
@@ -80,8 +80,8 @@ config_t config_open(const char *fname) {
 		 * Is it a section?
 		 */
 		if (buf[j] == '[') {
-			for (++j; j < len && isspace((u_char)buf[j]); ++j) {};
-			for (slen = j; j < len && j-slen < MINIBUF_SIZE-1 && buf[j] != ']' && !isspace((u_char)buf[j]); ++j) {};
+			for (++j; j < len && isspace((u_char)buf[j]); ++j);
+			for (slen = j; j < len && j-slen < MINIBUF_SIZE-1 && buf[j] != ']' && !isspace((u_char)buf[j]); ++j);
 			if (j-slen > 0) {
 				strlcpy(section, buf+slen, j-slen+1);
 			}
@@ -91,12 +91,12 @@ config_t config_open(const char *fname) {
 		/*
 		 * It's an OK keyword
 		 */
-		char * key = substr(buf, i, j-i);
+		char * key = substr(buf, (int)i, (int)(j-i));
 
 		/*
 		 * Find next non-empty character
 		 */
-		for (; j < len && isspace((u_char)buf[j]); ++j) {};
+		for (; j < len && isspace((u_char)buf[j]); ++j);
 		if (j >= len || buf[j] == '#' || buf[j] == ';') {
 			free(key);
 			continue;
@@ -107,7 +107,7 @@ config_t config_open(const char *fname) {
 		 */
 		if (buf[j] == '"') {
 			quote = 1;
-			for (i = ++j; j < len && buf[i] != '"'; ++i) {};
+			for (i = ++j; j < len && buf[i] != '"'; ++i);
 			if (i >= len) {
 				free(key);
 				continue;
@@ -118,10 +118,10 @@ config_t config_open(const char *fname) {
 		/*
 		 * Get value as quoted or until EOL/comment
 		 */
-		char * value = substr(buf, j, i-j);
+		char * value = substr(buf, (int)j, (int)(i-j));
 		if (!quote) {
 			i = strcspn(value, "#");
-			if (i != (int)strlen(value))
+			if (i != strlen(value))
 				value[i] = 0;
 			trimr(value);
 		}
@@ -153,7 +153,7 @@ char *config_pop(config_t cf, const char *option) {
 	return tmp;
 }
 
-int config_count(config_t cf) {
+int config_count(config_const_t cf) {
 	return hlist_count(cf->options);
 }
 

--- a/config.h
+++ b/config.h
@@ -29,6 +29,7 @@
 #define CFG_DEFAULT(cf, opt, var, size) { char *__tmp = NULL; if ((__tmp=config_pop(cf, opt)) && !strlen(var)) { strlcpy(var, __tmp, size); } if (__tmp) free(__tmp); }
 
 typedef struct config_s *config_t;
+typedef const struct config_s *config_const_t;
 struct config_s {
 	hlist_t options;
 };
@@ -36,7 +37,7 @@ struct config_s {
 extern config_t config_open(const char *fname);
 extern void config_set(config_t cf, char *option, char *value);
 extern char *config_pop(config_t cf, const char *option);
-extern int config_count(config_t cf);
+extern int config_count(config_const_t cf);
 extern void config_close(config_t cf);
 
 #endif /* CONFIG_H */

--- a/doc/cntlm.1
+++ b/doc/cntlm.1
@@ -375,7 +375,22 @@ some proxies require this field non-empty.
 
 .TP
 .B -x <PAC_file>\ \ \ \ (Pac)
-Specify a PAC file to load.
+Specify a PAC file to load. Two forms are supported:
+.RS
+.IP \(bu 2
+Local file: a filesystem path (for example /etc/proxy.pac). The PAC is
+read and parsed during startup; failure to access or parse a required local
+PAC will cause cntlm to exit with an error.
+.IP \(bu 2
+Remote file: an HTTP URL (for example http://example.com/proxy.pac). The PAC
+is fetched lazily on the first incoming connection to avoid blocking startup;
+after a successful fetch and parse the PAC is used for parent-proxy selection.
+Only plain HTTP (http://) is supported for remote PAC fetching (HTTPS is not
+supported).
+.PP
+The PAC is used to determine the appropriate parent proxy for a request's
+target host/URL. See the configuration file for examples and additional notes.
+.RE
 
 .TP
 .B -X <sspi_handle_type>\ \ \ \ (SSPI)

--- a/doc/cntlm.conf
+++ b/doc/cntlm.conf
@@ -41,8 +41,20 @@ NoProxy		localhost, 127.0.0.*, 10.*, 192.168.*
 
 # Use a proxy auto-configuration (PAC) file to determine the parent
 # proxy based on the request's target host/URL.
-# Specify the PAC file path
-#Pac /path/to/proxy.pac
+# Specify the PAC file path. Two usage modes are supported:
+#  - Local file: a filesystem path (e.g. /etc/proxy.pac). The PAC will be
+#    resolved and parsed immediately at startup. If the file cannot be read
+#    or parsed, cntlm will exit with an error.
+#  - Remote URL: an HTTP URL (e.g. http://example.com/proxy.pac). The PAC
+#    will be fetched lazily on the first incoming connection to avoid
+#    blocking startup on network access. Only http:// (not https://) is
+#    supported for remote PAC fetching. After a successful fetch and parse
+#    the PAC is used for proxy selection. Fetch or parse failures are logged
+#    and may cause termination depending on configuration.
+#
+# Examples:
+#Pac /etc/proxy.pac
+#Pac http://intra.example.com/proxy.pac
 
 # Specify the port cntlm will listen on
 # You can bind cntlm to specific interface by specifying

--- a/http.c
+++ b/http.c
@@ -916,7 +916,17 @@ int fetch_url(const char *url, char **outbuf, size_t *outlen, int *outcode) {
 	req->method = strdup("GET");
 	req->url = strdup(path);
 	req->http = strdup("HTTP/1.1");
-	req->headers = hlist_add(req->headers, "Host", host, HLIST_ALLOC, HLIST_ALLOC);
+	
+	/* Build Host header - include port for non-standard ports */
+	if (port != 80) {
+		size_t host_len = strlen(host) + 7; /* host + ":65535" + null */
+		char *host_header = zmalloc(host_len);
+		snprintf(host_header, host_len, "%s:%d", host, port);
+		req->headers = hlist_add(req->headers, "Host", host_header, HLIST_ALLOC, HLIST_NOALLOC);
+	} else {
+		req->headers = hlist_add(req->headers, "Host", host, HLIST_ALLOC, HLIST_ALLOC);
+	}
+	
 	req->headers = hlist_add(req->headers, "User-Agent", "cntlm-fetch/1.0", HLIST_ALLOC, HLIST_ALLOC);
 	req->headers = hlist_add(req->headers, "Connection", "close", HLIST_ALLOC, HLIST_ALLOC);
 

--- a/http.h
+++ b/http.h
@@ -46,5 +46,6 @@ extern int tunnel(int cd, int sd);
 extern length_t http_has_body(rr_data_const_t request, rr_data_const_t response);
 extern int http_body_send(int writefd, int readfd, rr_data_const_t request, rr_data_const_t response);
 extern int http_body_drop(int fd, rr_data_const_t response);
+extern int fetch_url(const char *url, char **outbuf, size_t *outlen, int *outcode);
 
 #endif /* HTTP_H */

--- a/main.c
+++ b/main.c
@@ -1051,7 +1051,7 @@ int main(int argc, char **argv) {
 		fprintf(stream, "\t-w  <workstation>\n"
 				"\t    Some proxies require correct NetBIOS hostname.\n");
 		fprintf(stream, "\t-x  <PAC_file>\n"
-				"\t    Specify a PAC file to load.\n");
+				"\t    Specify a PAC file to load. Local files or http URLs are supported.\n");
 		fprintf(stream, "\t-X  <sspi_handle_type>\n"
 				"\t    Use SSPI with specified handle type. Works only under Windows.\n"
 				"\t    Default is negotiate.\n");

--- a/ntlm.c
+++ b/ntlm.c
@@ -229,13 +229,13 @@ int ntlm_request(char **dst, struct auth_s *creds) {
 #endif
 	char *buf;
 	char *tmp;
-	int dlen;
-	int hlen;
+	uint16_t dlen;
+	uint16_t hlen;
 	uint32_t flags = 0xb206;
 
 	*dst = NULL;
-	dlen = strlen(creds->domain);
-	hlen = strlen(creds->workstation);
+	dlen = (uint16_t)strlen(creds->domain);
+	hlen = (uint16_t)strlen(creds->workstation);
 
 	if (!creds->flags) {
 		if (creds->hashntlm2)
@@ -290,30 +290,14 @@ int ntlm_request(char **dst, struct auth_s *creds) {
 
 static char *printuc(const char *src, size_t len) {
 	char *tmp;
-	size_t i;
 
 	tmp = zmalloc((len+1)/2 + 1);
-	for (i = 0; i < len/2; ++i) {
+	for (size_t i = 0; i < len/2; ++i) {
 		tmp[i] = src[i*2];
 	}
 
 	return tmp;
 }
-
-/*
-void dump(char *src, int len) {
-	int i, j;
-	char *tmp;
-
-	tmp = new(len*3+4);
-	for (i = 0; i < len; ++i) {
-		snprintf(tmp+i*3, 4, "%0hhX   ", src[i]);
-		printf("%c ", src[i]);
-	}
-	printf("\n%s\n", tmp);
-	free(tmp);
-}
-*/
 
 int ntlm_response(char **dst, char *challenge, int challen, struct auth_s *creds) {
 #ifdef __CYGWIN__
@@ -327,9 +311,9 @@ int ntlm_response(char **dst, char *challenge, int challen, struct auth_s *creds
 	char *uuser;
 	char *uhost;
 	char *tmp;
-	size_t dlen;
-	size_t ulen;
-	size_t hlen;
+	uint16_t dlen;
+	uint16_t ulen;
+	uint16_t hlen;
 	uint16_t tpos;
 	uint16_t tlen;
 	uint16_t ttype = -1;
@@ -411,20 +395,20 @@ int ntlm_response(char **dst, char *challenge, int challen, struct auth_s *creds
 
 	if (creds->hashnt || creds->hashntlm2) {
 		tmp = uppercase(strdup(creds->domain));
-		dlen = unicode(&udomain, tmp);
+		dlen = (uint16_t)unicode(&udomain, tmp);
 		free(tmp);
-		ulen = unicode(&uuser, creds->user);
+		ulen = (uint16_t)unicode(&uuser, creds->user);
 		tmp = uppercase(strdup(creds->workstation));
-		hlen = unicode(&uhost, tmp);
+		hlen = (uint16_t)unicode(&uhost, tmp);
 		free(tmp);
 	} else {
 		udomain = uppercase(strdup(creds->domain));
 		uuser = uppercase(strdup(creds->user));
 		uhost = uppercase(strdup(creds->workstation));
 
-		dlen = strlen(creds->domain);
-		ulen = strlen(creds->user);
-		hlen = strlen(creds->workstation);
+		dlen = (uint16_t)strlen(creds->domain);
+		ulen = (uint16_t)strlen(creds->user);
+		hlen = (uint16_t)strlen(creds->workstation);
 	}
 
 	if (debug) {
@@ -449,13 +433,13 @@ int ntlm_response(char **dst, char *challenge, int challen, struct auth_s *creds
 	VAL(buf, uint32_t, 8) = U32LE(3);
 
 	/* LM */
-	VAL(buf, uint16_t, 12) = U16LE(lmlen);
-	VAL(buf, uint16_t, 14) = U16LE(lmlen);
+	VAL(buf, uint16_t, 12) = U16LE((uint16_t)lmlen);
+	VAL(buf, uint16_t, 14) = U16LE((uint16_t)lmlen);
 	VAL(buf, uint32_t, 16) = U32LE(64+dlen+ulen+hlen);
 
 	/* NT */
-	VAL(buf, uint16_t, 20) = U16LE(ntlen);
-	VAL(buf, uint16_t, 22) = U16LE(ntlen);
+	VAL(buf, uint16_t, 20) = U16LE((uint16_t)ntlen);
+	VAL(buf, uint16_t, 22) = U16LE((uint16_t)ntlen);
 	VAL(buf, uint32_t, 24) = U32LE(64+dlen+ulen+hlen+lmlen);
 
 	/* Domain */
@@ -476,7 +460,7 @@ int ntlm_response(char **dst, char *challenge, int challen, struct auth_s *creds
 	/* Session */
 	VAL(buf, uint16_t, 52) = U16LE(0);
 	VAL(buf, uint16_t, 54) = U16LE(0);
-	VAL(buf, uint16_t, 56) = U16LE(64+dlen+ulen+hlen+lmlen+ntlen);
+	VAL(buf, uint16_t, 56) = U16LE((uint16_t)(64+dlen+ulen+hlen+lmlen+ntlen));
 
 	/* Flags */
 	VAL(buf, uint32_t, 60) = VAL(challenge, uint32_t, 20);

--- a/pac.c
+++ b/pac.c
@@ -94,6 +94,11 @@ char *read_file(const char* filename) {
     len = ftell(fd);
     fseek(fd, 0L, SEEK_SET);	
 
+    if (len == 0) {
+        fclose(fd);
+        return NULL;
+    }
+
     buf = (char*)calloc(len+1, sizeof(char));	
     if(buf == NULL) {
         fclose(fd);

--- a/proxy.c
+++ b/proxy.c
@@ -496,7 +496,7 @@ int proxy_connect(struct auth_s *credentials, const char* url, const char* hostn
 		plist_const_t list = connection_list;
 		while (list) {
 			plist_const_t tmp = list->next;
-			close(list->key);
+			close((int)(list->key));
 			list = tmp;
 		}
 		plist_free(connection_list);

--- a/scanner.c
+++ b/scanner.c
@@ -59,8 +59,6 @@ int scanner_hook(rr_data_const_t request, rr_data_t response, struct auth_s *cre
 	int done = 0;
 	int headers_initiated = 0;
 	int c;
-	long progress = 0;
-	long filesize = 0;
 
 	/*
 	 * Let's limit the responses we examine to an absolute minimum
@@ -110,6 +108,9 @@ int scanner_hook(rr_data_const_t request, rr_data_t response, struct auth_s *cre
 		for (i = 0; i < c && pos[i] != '"'; ++i);
 
 		if (pos[i] == '"') {
+			long progress = 0;
+			long filesize = 0;
+
 			isaid = substr(pos, 0, i);
 			if (debug)
 				printf("scanner_hook: ISA id = %s\n", isaid);

--- a/utils.c
+++ b/utils.c
@@ -870,8 +870,6 @@ char *printmem(const char * const src, const size_t len, const int bitwidth) {
 }
 
 char *scanmem(const char * const src, const int bitwidth) {
-	int h;
-	int l;
 	size_t i;
 	size_t bytes;
 	char *tmp;
@@ -882,8 +880,8 @@ char *scanmem(const char * const src, const int bitwidth) {
 	bytes = strlen(src)/2;
 	tmp = zmalloc(bytes+1);
 	for (i = 0; i < bytes; ++i) {
-		h = hexindex[(int)src[i*2]];
-		l = hexindex[(int)src[i*2+1]];
+		int h = hexindex[(int)src[i*2]];
+		int l = hexindex[(int)src[i*2+1]];
 		if (h < 0 || l < 0) {
 			free(tmp);
 			return NULL;
@@ -977,21 +975,18 @@ void to_base64(unsigned char *out, const unsigned char *in, size_t len, size_t o
 int from_base64(char *out, const char *in)
 {
 	int len = 0;
-	register unsigned char digit1;
-	register unsigned char digit2;
-	register unsigned char digit3;
-	register unsigned char digit4;
+	uint8_t digit4;
 
 	do {
-		digit1 = in[0];
+		uint8_t digit1 = in[0];
 		if (digit1 > 127 || base64val (digit1) == BAD)
 			return -1;
 
-		digit2 = in[1];
+		uint8_t digit2 = in[1];
 		if (digit2 > 127 || base64val (digit2) == BAD)
 			return -1;
 
-		digit3 = in[2];
+		uint8_t digit3 = in[2];
 		if (digit3 > 127 || ((digit3 != '=') && (base64val (digit3) == BAD)))
 			return -1;
 

--- a/xcrypt.c
+++ b/xcrypt.c
@@ -72,9 +72,9 @@
 #define G(x, y, z) (((x) & (y)) | ((x) & (z)) | ((y) & (z)))
 #define H(x, y, z) ((x) ^ (y) ^ (z))
 #define rol(x, n) (((x) << (n)) | ((uint32_t) (x) >> (32 - (n))))
-#define R1(a,b,c,d,k,s) a=rol(a+F(b,c,d)+x[k],s);
-#define R2(a,b,c,d,k,s) a=rol(a+G(b,c,d)+x[k]+K1,s);
-#define R3(a,b,c,d,k,s) a=rol(a+H(b,c,d)+x[k]+K2,s);
+#define R1(a,b,c,d,k,s) a=rol(a+F(b,c,d)+x[k],s)
+#define R2(a,b,c,d,k,s) a=rol(a+G(b,c,d)+x[k]+K1,s)
+#define R3(a,b,c,d,k,s) a=rol(a+H(b,c,d)+x[k]+K2,s)
 
 /* This array contains the bytes used to pad the buffer to the next
    64-byte boundary.  (RFC 1320, 3.1: Step 1)  */
@@ -301,10 +301,13 @@ static const unsigned char weak_keys[64][8] = {
 
 bool gl_des_is_weak_key (const char * key) {
   char work[8];
-  int i, left, right, middle, cmp_result;
+  int left;
+  int right;
+  int middle;
+  int cmp_result;
 
   /* clear parity bits */
-  for (i = 0; i < 8; ++i)
+  for (int i = 0; i < 8; ++i)
     work[i] = ((unsigned char)key[i]) & 0xfe;
 
   /* binary search in the weak key table */
@@ -410,8 +413,9 @@ bool gl_des_is_weak_key (const char * key) {
  */
 static void des_key_schedule (const char * _rawkey, uint32_t * subkey) {
   const unsigned char *rawkey = (const unsigned char *) _rawkey;
-  uint32_t left, right, work;
-  int round;
+  uint32_t left;
+  uint32_t right;
+  uint32_t work;
 
   READ_64BIT_DATA (rawkey, left, right)
     DO_PERMUTATION (right, work, left, 4, 0x0f0f0f0f)
@@ -438,7 +442,7 @@ static void des_key_schedule (const char * _rawkey, uint32_t * subkey) {
 
   right &= 0x0fffffff;
 
-  for (round = 0; round < 16; ++round)
+  for (int round = 0; round < 16; ++round)
     {
       left = ((left << encrypt_rotate_tab[round])
               | (left >> (28 - encrypt_rotate_tab[round]))) & 0x0fffffff;
@@ -494,11 +498,9 @@ static void des_key_schedule (const char * _rawkey, uint32_t * subkey) {
 }
 
 void gl_des_setkey (gl_des_ctx *ctx, const char * key) {
-  int i;
-
   des_key_schedule (key, ctx->encrypt_subkeys);
 
-  for (i = 0; i < 32; i += 2)
+  for (int i = 0; i < 32; i += 2)
     {
       ctx->decrypt_subkeys[i] = ctx->encrypt_subkeys[30 - i];
       ctx->decrypt_subkeys[i + 1] = ctx->encrypt_subkeys[31 - i];
@@ -517,8 +519,10 @@ bool gl_des_makekey (gl_des_ctx *ctx, const char * key, size_t keylen) {
 void gl_des_ecb_crypt (gl_des_ctx *ctx, const char * _from, char * _to, int mode) {
   const unsigned char *from = (const unsigned char *) _from;
   unsigned char *to = (unsigned char *) _to;
-  uint32_t left, right, work;
-  uint32_t *keys;
+  uint32_t left;
+  uint32_t right;
+  uint32_t work;
+  const uint32_t *keys;
 
   keys = mode ? ctx->decrypt_subkeys : ctx->encrypt_subkeys;
 
@@ -559,8 +563,7 @@ void md4_process_block (const void *buffer, size_t len, struct md4_ctx *ctx) {
      the loop.  */
   while (words < endp)
     {
-      int t;
-      for (t = 0; t < 16; t++)
+      for (int t = 0; t < 16; t++)
         {
           x[t] = SWAP (*words);
           words++;

--- a/xcrypt.c
+++ b/xcrypt.c
@@ -303,8 +303,6 @@ bool gl_des_is_weak_key (const char * key) {
   char work[8];
   int left;
   int right;
-  int middle;
-  int cmp_result;
 
   /* clear parity bits */
   for (int i = 0; i < 8; ++i)
@@ -315,9 +313,10 @@ bool gl_des_is_weak_key (const char * key) {
   right = 63;
   while (left <= right)
     {
-      middle = (left + right) / 2;
+      int middle = (left + right) / 2;
 
-      if (!(cmp_result = memcmp (work, weak_keys[middle], 8)))
+      int cmp_result = memcmp(work, weak_keys[middle], 8);
+      if (cmp_result == 0)
         return -1;
 
       if (cmp_result > 0)


### PR DESCRIPTION
PAC files can only be loaded from local file system. This PR implements the download of a PAC file from an http server.
Now it is possible to define, e.g., `PAC http://intra.example.com/proxy.pac` in the `cntlm.conf`.
The file is downloaded just before the first connection request.