### PR TITLE
Add Windows SSPI Negotiate

### DIFF
--- a/doc/cntlm.1
+++ b/doc/cntlm.1
@@ -510,8 +510,8 @@ is interpreted literally).
 The hostname of your workstation. 
 
 .TP
-.B SSPI NTLM
-Enable SSPI for Windows clients. Only NTLM is supported for now.
+.B SSPI NTLM | Negotiate
+Enable SSPI for Windows clients. Only NTLM and Negotiate are supported for now.
 
 .ne 7
 .SH FILES

--- a/doc/cntlm.conf
+++ b/doc/cntlm.conf
@@ -101,6 +101,6 @@ Listen		3128
 #Tunnel		11443:remote.com:443
 
 # Enable SSPI for Windows clients.
-# Only NTLM is supported for now.
+# Only NTLM and Negotiate are supported for now.
 #
 #SSPI	NTLM

--- a/main.c
+++ b/main.c
@@ -1504,7 +1504,7 @@ int main(int argc, char **argv) {
 			!g_creds->haskrb &&
 #endif
 #ifdef __CYGWIN__
-			!sspi_enabled() &&
+			sspi_is_ntlm() &&
 #endif
 			    ((g_creds->hashnt && is_memory_all_zero(g_creds->passnt, ARRAY_SIZE(g_creds->passnt)))
 			 || (g_creds->hashlm && is_memory_all_zero(g_creds->passlm, ARRAY_SIZE(g_creds->passlm)))

--- a/ntlm.c
+++ b/ntlm.c
@@ -222,9 +222,9 @@ char *ntlm2_hash_password(const char *username, const char *domain, const char *
 
 int ntlm_request(char **dst, struct auth_s *creds) {
 #ifdef __CYGWIN__
-	if (sspi_enabled())
+	if (sspi_is_ntlm())
 	{
-		return sspi_request(dst, &creds->sspi);
+		return sspi_ntlm_request(dst, &creds->sspi);
 	}
 #endif
 	char *buf;
@@ -317,9 +317,9 @@ void dump(char *src, int len) {
 
 int ntlm_response(char **dst, char *challenge, int challen, struct auth_s *creds) {
 #ifdef __CYGWIN__
-	if (sspi_enabled())
+	if (sspi_is_ntlm())
 	{
-		return sspi_response(dst, challenge, challen, &creds->sspi);
+		return sspi_ntlm_response(dst, challenge, challen, &creds->sspi);
 	}
 #endif
 	char *buf;

--- a/proxy.c
+++ b/proxy.c
@@ -36,6 +36,17 @@
 #include "kerberos.h"
 #endif
 
+#ifdef __CYGWIN__
+// Thread-local storage for Negotiate state
+static pthread_key_t negotiate_state_key;
+static pthread_once_t key_once = PTHREAD_ONCE_INIT;
+
+// Helper function to create the key
+static void make_negotiate_key(void) {
+    pthread_key_create(&negotiate_state_key, NULL);
+}
+#endif
+
 /*
  * Proxy types defined by PAC specification. Used in proxy_t to
  * specify proxy type.
@@ -87,7 +98,7 @@ proxylist_t parent_list = NULL;
 unsigned long parent_curr = 0;
 pthread_mutex_t parent_mtx = PTHREAD_MUTEX_INITIALIZER;
 
-#if config_gss == 1
+#if config_gss == 1 || defined(__CYGWIN__)
 proxy_t *curr_proxy;
 #endif
 
@@ -477,7 +488,7 @@ int proxy_connect(struct auth_s *credentials, const char* url, const char* hostn
 				proxy = p->proxy;
 				syslog(LOG_ERR, "Proxy connect failed, will try %s:%d\n", proxy->hostname, proxy->port);
 			}
-#if config_gss == 1
+#if config_gss == 1 || defined(__CYGWIN__)
 		} else {
 			//kerberos needs the hostname of the parent proxy for generate the token, so we keep it
 			curr_proxy = proxy;
@@ -550,14 +561,34 @@ int proxy_authenticate(int *sd, rr_data_t request, rr_data_t response, struct au
 			printf("Using Negotiation ...\n");
 	}
 	else {
-#endif
-
-		strlcpy(buf, "NTLM ", bufsize);
-		len = ntlm_request(&tmp, credentials);
+#elif defined(__CYGWIN__)
+	if (sspi_is_negotiate()) {
+		// Get scheme from SSPI (returns "NTLM" or "Negotiate")
+		snprintf(buf, bufsize, "%s ", sspi_get_scheme());
+		int prefix_len = strlen(buf);
+		
+		pthread_once(&key_once, make_negotiate_key);
+		struct sspi_negotiate_state *negotiate_state = pthread_getspecific(negotiate_state_key);
+		if (!negotiate_state) {
+			negotiate_state = zmalloc(sizeof(struct sspi_negotiate_state));
+			pthread_setspecific(negotiate_state_key, negotiate_state);
+		}
+		len = sspi_negotiate(&tmp, negotiate_state, curr_proxy->hostname);
 		if (len) {
-			to_base64(MEM(buf, uint8_t, 5), MEM(tmp, uint8_t, 0), len, bufsize-5);
+			to_base64(MEM(buf, uint8_t, prefix_len), MEM(tmp, uint8_t, 0), len, bufsize - prefix_len);
 			free(tmp);
 		}
+	}
+	else {
+#endif
+		// Traditional NTLM fallback
+		strlcpy(buf, "NTLM ", bufsize);
+    	len = ntlm_request(&tmp, credentials);
+    	if (len) {
+			to_base64(MEM(buf, uint8_t, 5), MEM(tmp, uint8_t, 0), len, bufsize - 5);
+			free(tmp);
+		}
+	}
 
 #if config_gss == 1
 	}
@@ -654,6 +685,26 @@ int proxy_authenticate(int *sd, rr_data_t request, rr_data_t response, struct au
 				request->headers = hlist_mod(request->headers, "Proxy-Authorization", buf, 1);
 			}
 			else {
+#elif defined(__CYGWIN__)
+		if (sspi_is_negotiate()) {
+			// Get scheme from SSPI (returns "NTLM" or "Negotiate")
+			snprintf(buf, bufsize, "%s ", sspi_get_scheme());
+			int prefix_len = strlen(buf);
+			
+			pthread_once(&key_once, make_negotiate_key);
+			struct sspi_negotiate_state *negotiate_state = pthread_getspecific(negotiate_state_key);
+			if (!negotiate_state) {
+				negotiate_state = zmalloc(sizeof(struct sspi_negotiate_state));
+				memset(negotiate_state, 0, sizeof(struct sspi_negotiate_state));
+				pthread_setspecific(negotiate_state_key, negotiate_state);
+			}
+			len = sspi_negotiate(&tmp, negotiate_state, curr_proxy->hostname);
+			if (len) {
+				to_base64(MEM(buf, uint8_t, prefix_len), MEM(tmp, uint8_t, 0), len, bufsize - prefix_len);
+				free(tmp);
+			}
+		}
+		else {
 #endif
 				challenge = zmalloc(strlen(tmp) + 5 + 1);
 				len = from_base64(challenge, tmp + 5);
@@ -680,7 +731,7 @@ int proxy_authenticate(int *sd, rr_data_t request, rr_data_t response, struct au
 				}
 
 				free(challenge);
-#if config_gss == 1
+#if config_gss == 1 || defined(__CYGWIN__)
 			}
 #endif
 		} else {

--- a/sspi.c
+++ b/sspi.c
@@ -24,6 +24,7 @@
 
 #include "sspi.h"
 #include "utils.h"
+#include <syslog.h>
 
 // SSPI mode
 #ifdef UNICODE
@@ -182,10 +183,43 @@ int sspi_enabled(void)
 	return 0;
 }
 
+int sspi_is_negotiate(void) {
+    if (!sspi_enabled())
+        return 0;
+#ifdef UNICODE
+    return (wcscmp(sspi_mode, L"Negotiate") == 0);
+#else
+    return (strcasecmp(sspi_mode, "Negotiate") == 0);
+#endif
+}
+
+int sspi_is_ntlm(void) {
+    if (!sspi_enabled())
+        return 0;
+#ifdef UNICODE
+    return (wcscmp(sspi_mode, L"NTLM") == 0);
+#else
+    return (strcasecmp(sspi_mode, "NTLM") == 0);
+#endif
+}
+
+const char* sspi_get_scheme(void) {
+    if (!sspi_enabled())
+        return "NTLM";
+        
+#ifdef UNICODE
+    static char scheme[32];
+    wcstombs(scheme, sspi_mode, sizeof(scheme));
+    return scheme;
+#else
+    return sspi_mode;
+#endif
+}
+
 int sspi_set(char* mode)
 {
 	sspi_dll = LoadSecurityDll();
-	if (!strcasecmp("NTLM", mode) && sspi_dll)  // Only NTLM supported for now
+	if ((!strcasecmp("NTLM", mode) || !strcasecmp("Negotiate", mode)) && sspi_dll)  // Only NTLM and Negotiate supported for now
 	{
 #ifdef UNICODE
 		sspi_mode = zmalloc(sizeof(wchar_t) * strlen(mode));
@@ -208,7 +242,7 @@ int sspi_unset(void)
 	return 1;
 }
 
-int sspi_request(char **dst, struct sspi_handle *sspi)
+int sspi_ntlm_request(char **dst, struct sspi_handle *sspi)
 {
 	SECURITY_STATUS status;
 	TimeStamp expiry;
@@ -264,7 +298,7 @@ int sspi_request(char **dst, struct sspi_handle *sspi)
 	return token.cbBuffer;
 }
 
-int sspi_response(char **dst, char *challengeBuf, int challen, struct sspi_handle *sspi)
+int sspi_ntlm_response(char **dst, char *challengeBuf, int challen, struct sspi_handle *sspi)
 {
 	SecBuffer challenge;
 	SecBuffer answer;
@@ -306,6 +340,77 @@ int sspi_response(char **dst, char *challengeBuf, int challen, struct sspi_handl
 
 	*dst = answer.pvBuffer;
 	return answer.cbBuffer;
+}
+
+int sspi_negotiate(char **dst, struct sspi_negotiate_state *state, const char *proxy_hostname)
+{
+    SECURITY_STATUS status;
+    TimeStamp expiry;
+    SecBufferDesc output_desc;
+    SecBuffer output_buffer;
+    unsigned int context_attr;
+    
+    // Step 1: Acquire credentials handle with Negotiate package
+    status = _AcquireCredentialsHandle(
+        NULL,
+        TEXT("Negotiate"),
+        SECPKG_CRED_OUTBOUND,
+        NULL, NULL, NULL, NULL,
+        &state->credentials,
+        &expiry);
+    
+    if (status != SEC_E_OK) {
+        syslog(LOG_ERR, "AcquireCredentialsHandle failed: 0x%08x", status);
+        return 0;
+    }
+    
+    // Build SPN from proxy hostname
+    char hostname_only[256];
+    snprintf(hostname_only, sizeof(hostname_only), "%s", proxy_hostname ? proxy_hostname : "");
+    char *colon = strchr(hostname_only, ':');
+    if (colon) *colon = '\0';
+    
+    // Step 2: Initialize security context
+    output_desc.ulVersion = SECBUFFER_VERSION;
+    output_desc.cBuffers = 1;
+    output_desc.pBuffers = &output_buffer;
+    output_buffer.cbBuffer = TOKEN_BUFSIZE;
+    output_buffer.BufferType = SECBUFFER_TOKEN;
+    output_buffer.pvBuffer = zmalloc(TOKEN_BUFSIZE);
+    
+#ifdef UNICODE
+    wchar_t target_name[261]; // 256 + 5 chars
+    wchar_t whostname[256];
+    mbstowcs(whostname, hostname_only, 256);
+    swprintf(target_name, 256, L"HTTP/%s", whostname);
+#else
+    char target_name[261]; // 256 + 5 chars
+    snprintf(target_name, sizeof(target_name), "HTTP/%s", hostname_only);
+#endif
+    
+    status = _InitializeSecurityContext(
+        &state->credentials,
+        NULL,
+        target_name,
+        ISC_REQ_CONFIDENTIALITY | ISC_REQ_REPLAY_DETECT | ISC_REQ_CONNECTION,
+        0,
+        SECURITY_NETWORK_DREP,
+        NULL,
+        0,
+        &state->context,
+        &output_desc,
+        &context_attr,
+        &expiry);
+    
+    if (status != SEC_E_OK && status != SEC_I_CONTINUE_NEEDED) {
+        syslog(LOG_ERR, "InitializeSecurityContext failed: 0x%08x", status);
+        _FreeCredentialsHandle(&state->credentials);
+        free(output_buffer.pvBuffer);
+        return 0;
+    }
+    *dst = output_buffer.pvBuffer;
+    
+    return output_buffer.cbBuffer;
 }
 
 #endif /*  __CYGWIN__ */

--- a/sspi.h
+++ b/sspi.h
@@ -29,6 +29,7 @@
 
 #include <windows.h>
 #include <sspi.h>
+#include <stdio.h>
 
 #define TOKEN_BUFSIZE 4096
 
@@ -38,12 +39,22 @@ struct sspi_handle
 	CtxtHandle context;
 };
 
+struct sspi_negotiate_state {
+    CredHandle credentials;
+    CtxtHandle context;
+};
+
+extern int sspi_negotiate(char **dst, struct sspi_negotiate_state *state, const char *proxy_hostname);
+extern const char* sspi_get_scheme(void);
+
 extern int sspi_enabled(void);
+extern int sspi_is_negotiate(void);
+extern int sspi_is_ntlm(void);
 extern int sspi_set(char *mode);
 extern int sspi_unset(void);
 
-extern int sspi_request(char **dst, struct sspi_handle *sspi);
-extern int sspi_response(char **dst, char *challenge, int challen, struct sspi_handle *sspi);
+extern int sspi_ntlm_request(char **dst, struct sspi_handle *sspi);
+extern int sspi_ntlm_response(char **dst, char *challenge, int challen, struct sspi_handle *sspi);
 
 #endif /*  __CYGWIN__ */
 


### PR DESCRIPTION
In this PR, I add support of SSPI Negotiate for Windows. (Previously only NTLM is supported)
SSPI Negotiate mode directly generates a Kerberos ticket to inherit the user session. No login or password are needed.
Also, the authenticate is done on one-shot (no 407 Proxy Authentication Required received but directly 200 Connection Established)
I tested it with our corporate proxy successfully.

Kindly review it.

Note: I didn't integrate it to the -M switch (automatic configuration detection)